### PR TITLE
✨(subscription) import external ICS calendar feeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ start: ## start all development services
 .PHONY: start
 
 start-back: ## start backend services only (for local frontend development)
-	@$(COMPOSE) up --force-recreate -d worker-dev subscription-scheduler
+	@$(COMPOSE) up --force-recreate -d backend-dev worker-dev subscription-scheduler
 .PHONY: start-back
 
 status: ## an alias for "docker compose ps"

--- a/Makefile
+++ b/Makefile
@@ -107,11 +107,11 @@ logs: ## display all services logs (follow mode)
 .PHONY: logs
 
 start: ## start all development services
-	@$(COMPOSE) up --force-recreate -d worker-dev frontend-dev backend-dev keycloak
+	@$(COMPOSE) up --force-recreate -d worker-dev frontend-dev backend-dev keycloak subscription-scheduler
 .PHONY: start
 
 start-back: ## start backend services only (for local frontend development)
-	@$(COMPOSE) up --force-recreate -d worker-dev
+	@$(COMPOSE) up --force-recreate -d worker-dev subscription-scheduler
 .PHONY: start-back
 
 status: ## an alias for "docker compose ps"
@@ -271,6 +271,21 @@ reset-db: build ## flush database and re-run migrations
 	@$(MAKE) migrate
 	@$(MAKE) migrate-caldav
 .PHONY: reset-db
+
+reset-db-full: ## drop and recreate database, run all migrations + CalDAV schema
+	@echo "$(BOLD)Stopping services using the database...$(RESET)"
+	@$(COMPOSE) stop backend-dev worker-dev caldav subscription-scheduler 2>/dev/null || true
+	@$(COMPOSE) up -d postgresql
+	@sleep 2
+	@echo "$(BOLD)Dropping and recreating database...$(RESET)"
+	@$(COMPOSE) exec postgresql psql -U pgroot -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'calendars' AND pid <> pg_backend_pid();" > /dev/null 2>&1 || true
+	@$(COMPOSE) exec postgresql dropdb -U pgroot --if-exists calendars
+	@$(COMPOSE) exec postgresql createdb -U pgroot calendars
+	@echo "$(GREEN)Database recreated$(RESET)"
+	@$(MAKE) migrate
+	@$(MAKE) migrate-caldav
+	@echo "$(GREEN)All migrations applied. Run 'make start' to restart services.$(RESET)"
+.PHONY: reset-db-full
 
 demo: ## flush db then create a demo
 	@$(MAKE) reset-db

--- a/compose.yaml
+++ b/compose.yaml
@@ -116,6 +116,30 @@ services:
       - ./src/frontend/apps/calendars/src/features/i18n/translations.json:/data/translations.json:ro
       - /app/.venv
 
+  subscription-scheduler:
+    user: ${DOCKER_USER:-1000}
+    image: calendars:backend-development
+    restart: unless-stopped
+    networks:
+      - default
+      - lasuite
+    command: [ "python", "manage.py", "run_subscription_scheduler" ]
+    environment:
+      - DJANGO_CONFIGURATION=Development
+    env_file:
+      - env.d/development/backend.defaults
+      - env.d/development/backend.local
+    volumes:
+      - ./src/backend:/app
+      - ./data/static:/data/static
+      - ./src/frontend/apps/calendars/src/features/i18n/translations.json:/data/translations.json:ro
+      - /app/.venv
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_started
+
   frontend-dev:
     user: "${DOCKER_USER:-1000}"
     build:

--- a/docs/external-subscriptions-test-plan.md
+++ b/docs/external-subscriptions-test-plan.md
@@ -1,0 +1,113 @@
+# Plan de test manuel — Import de calendriers externes
+
+## Prérequis
+
+- `make start` (tous les services up, y compris `subscription-scheduler`)
+- Être connecté sur http://localhost:8930
+- Avoir au moins un calendrier personnel existant
+- Avoir une URL ICS publique valide pour tester (ex: jours fériés français : `https://calendrier.api.gouv.fr/jours-feries/metropole.ics`, ou un calendrier Google public)
+
+---
+
+## 1. Ajout d'un abonnement
+
+### 1.1 Ouverture de la modale
+- [ ] Dans le panneau gauche, vérifier qu'une section **"Abonnements"** (ou "Subscriptions") apparaît sous les calendriers personnels
+- [ ] Cliquer sur le bouton `+` à côté du titre de la section
+- [ ] La modale "Ajouter un abonnement" s'ouvre
+
+### 1.2 Validation du formulaire
+- [ ] Soumettre sans URL → erreur de validation
+- [ ] Entrer une URL invalide (ex: `pas-une-url`) → soumettre → erreur du serveur affichée
+- [ ] Entrer une URL HTTP (pas HTTPS, ex: `http://example.com/cal.ics`) → erreur
+
+### 1.3 Ajout réussi
+- [ ] Entrer une URL ICS valide (HTTPS)
+- [ ] Optionnel : saisir un nom d'affichage
+- [ ] Optionnel : choisir une couleur
+- [ ] Cliquer "S'abonner" → spinner de chargement visible
+- [ ] La modale se ferme
+- [ ] Le calendrier apparaît dans la section "Abonnements"
+- [ ] Les événements du calendrier externe s'affichent dans le scheduler
+
+---
+
+## 2. Affichage read-only des événements
+
+### 2.1 Clic sur un événement d'abonnement
+- [ ] Cliquer sur un événement provenant d'un calendrier abonné
+- [ ] La modale **read-only** s'ouvre (pas le formulaire d'édition)
+- [ ] Vérifier l'affichage : titre, date/heure, lieu (si présent), description (si présente)
+- [ ] Vérifier que les participants sont listés avec leur statut (accepted, declined, etc.)
+- [ ] Vérifier qu'il n'y a **aucun bouton d'édition** ni de suppression
+
+### 2.2 Drag & drop bloqué
+- [ ] Essayer de drag-and-drop un événement d'abonnement → l'événement revient à sa position d'origine
+- [ ] Essayer de resize un événement d'abonnement → l'événement revient à sa taille d'origine
+
+### 2.3 Événements réguliers non impactés
+- [ ] Cliquer sur un événement d'un calendrier personnel → le formulaire d'édition normal s'ouvre
+- [ ] Drag & drop sur un événement personnel → fonctionne normalement
+- [ ] Créer un nouvel événement → le calendrier abonné n'apparaît PAS dans la liste des calendriers disponibles
+
+---
+
+## 3. Gestion des abonnements
+
+### 3.1 Édition
+- [ ] Cliquer sur le menu d'un calendrier abonné → option "Modifier"
+- [ ] Changer le nom → Sauvegarder → le nom est mis à jour dans la liste
+- [ ] Changer la couleur → Sauvegarder → la couleur est mise à jour (événements aussi)
+- [ ] Changer l'URL source → Sauvegarder → les anciens événements sont remplacés par les nouveaux
+
+### 3.2 Suppression
+- [ ] Cliquer sur le menu d'un calendrier abonné → option "Supprimer"
+- [ ] Le calendrier disparaît de la liste
+- [ ] Les événements associés disparaissent du scheduler
+
+### 3.3 Toggle visibilité
+- [ ] Décocher un calendrier abonné dans la liste → ses événements disparaissent du scheduler
+- [ ] Re-cocher → les événements réapparaissent
+
+---
+
+## 4. Status badge & synchronisation
+
+### 4.1 État normal
+- [ ] Après un ajout réussi, pas de badge visible (état "ok")
+
+### 4.2 État erreur (nécessite une URL qui va échouer)
+- [ ] Créer un abonnement avec une URL qui marche
+- [ ] Modifier l'URL vers une URL invalide (ex: `https://example.com/not-a-calendar`)
+- [ ] Attendre quelques minutes (ou forcer via l'API)
+- [ ] Un badge d'erreur (icône warning) apparaît
+- [ ] Cliquer dessus → le détail de l'erreur s'affiche
+
+### 4.3 État stoppé & réactivation
+- [ ] Après 3 erreurs consécutives, le badge passe en "stoppé" (icône block)
+- [ ] Le détail affiche un message explicatif + bouton "Réactiver"
+- [ ] Corriger l'URL (modifier vers une URL valide)
+- [ ] Cliquer "Réactiver" → le statut repasse en "pending" puis "ok"
+
+---
+
+## 5. Limites
+
+### 5.1 Limite d'abonnements (20 par défaut)
+- [ ] Si on a déjà 20 abonnements, le bouton `+` est désactivé ou un message "Limite atteinte" s'affiche
+
+---
+
+## 6. Section repliable
+
+- [ ] Cliquer sur le header "Abonnements" → la section se replie (les calendriers sont masqués)
+- [ ] Re-cliquer → la section se déplie
+- [ ] Quand la section est repliée, les événements restent visibles dans le scheduler (seul l'affichage de la liste est impacté)
+
+---
+
+## 7. Internationalisation
+
+- [ ] Changer la langue en FR → toutes les chaînes de la feature sont en français
+- [ ] Changer en EN → toutes les chaînes sont en anglais
+- [ ] Changer en NL → toutes les chaînes sont en néerlandais (pas de clés brutes visibles)

--- a/docs/external-subscriptions-test-plan.md
+++ b/docs/external-subscriptions-test-plan.md
@@ -21,6 +21,16 @@
 - [ ] Entrer une URL invalide (ex: `pas-une-url`) → soumettre → erreur du serveur affichée
 - [ ] Entrer une URL HTTP (pas HTTPS, ex: `http://example.com/cal.ics`) → erreur
 
+#### Protection SSRF
+- [ ] `https://localhost/cal.ics` → rejet (hôte privé)
+- [ ] `https://127.0.0.1/cal.ics` → rejet
+- [ ] `https://[::1]/cal.ics` → rejet
+- [ ] `https://10.0.0.1/cal.ics` (RFC1918) → rejet
+- [ ] `https://192.168.1.1/cal.ics` (RFC1918) → rejet
+- [ ] `https://172.16.0.1/cal.ics` (RFC1918) → rejet
+- [ ] Hôte public qui résout vers une IP privée → rejet
+- [ ] URL dont la chaîne de redirection 3xx aboutit à une adresse privée ou locale → rejet au hop concerné
+
 ### 1.3 Ajout réussi
 - [ ] Entrer une URL ICS valide (HTTPS)
 - [ ] Optionnel : saisir un nom d'affichage

--- a/src/backend/calendars/settings.py
+++ b/src/backend/calendars/settings.py
@@ -100,6 +100,16 @@ class Base(Configuration):
         None, environ_name="MESSAGES_CHANNEL_ID", environ_prefix=None
     )
 
+    # Default sync interval for subscription calendars (seconds)
+    SUBSCRIPTION_SYNC_INTERVAL = values.IntegerValue(
+        300, environ_name="SUBSCRIPTION_SYNC_INTERVAL", environ_prefix=None
+    )
+
+    # Maximum number of subscription channels per user
+    MAX_SUBSCRIPTIONS_PER_USER = values.IntegerValue(
+        20, environ_name="MAX_SUBSCRIPTIONS_PER_USER", environ_prefix=None
+    )
+
     # Default calendar sharing level for new organizations.
     # Controls what colleagues in the same org can see by default.
     # Values: "none", "freebusy", "read", "write"

--- a/src/backend/calendars/settings.py
+++ b/src/backend/calendars/settings.py
@@ -918,6 +918,11 @@ class Base(Configuration):
         """
         super().post_setup()
 
+        if cls.SUBSCRIPTION_SYNC_INTERVAL < 1:
+            raise ValueError("SUBSCRIPTION_SYNC_INTERVAL must be >= 1")
+        if cls.MAX_SUBSCRIPTIONS_PER_USER < 1:
+            raise ValueError("MAX_SUBSCRIPTIONS_PER_USER must be >= 1")
+
         # The SENTRY_DSN setting should be available to activate sentry for an environment
         if cls.SENTRY_DSN is not None:
             sentry_sdk.init(

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -227,24 +227,31 @@ class ChannelSubscriptionSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_source_url(self, obj) -> str:
+        """Resolve the source URL from the channel's settings JSON."""
         return obj.settings.get("source_url", "")
 
     def get_last_sync_at(self, obj) -> str | None:
+        """Resolve the last-sync timestamp from the channel's settings JSON."""
         return obj.settings.get("last_sync_at")
 
     def get_last_sync_status(self, obj) -> str:
+        """Resolve the last-sync status from the channel's settings JSON."""
         return obj.settings.get("last_sync_status", "pending")
 
     def get_last_sync_error(self, obj) -> str:
+        """Resolve the last-sync error string from the channel's settings JSON."""
         return obj.settings.get("last_sync_error", "")
 
     def get_error_count(self, obj) -> int:
+        """Resolve the consecutive-error count from the channel's settings JSON."""
         return obj.settings.get("error_count", 0)
 
     def get_sync_interval(self, obj) -> int:
-        return obj.settings.get("sync_interval", 300)
+        """Resolve the sync interval from the channel's settings JSON."""
+        return obj.settings.get("sync_interval", settings.SUBSCRIPTION_SYNC_INTERVAL)
 
 
+# pylint: disable-next=abstract-method
 class ChannelSubscriptionCreateSerializer(serializers.Serializer):
     """Write serializer for creating subscription channels."""
 
@@ -265,6 +272,7 @@ class ChannelSubscriptionCreateSerializer(serializers.Serializer):
             raise serializers.ValidationError(str(exc)) from exc
 
 
+# pylint: disable-next=abstract-method
 class ChannelSubscriptionUpdateSerializer(serializers.Serializer):
     """Write serializer for updating subscription channels."""
 

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -192,9 +192,97 @@ class ChannelCreateSerializer(serializers.Serializer):  # pylint: disable=abstra
 
     def validate_type(self, value):
         """Validate channel type."""
-        if value == "ical-feed":
+        if value in ("ical-feed", "ical-subscription"):
             return value
         return "caldav"
+
+
+class ChannelSubscriptionSerializer(serializers.ModelSerializer):
+    """Read serializer for subscription channels with sync status fields."""
+
+    source_url = serializers.SerializerMethodField()
+    last_sync_at = serializers.SerializerMethodField()
+    last_sync_status = serializers.SerializerMethodField()
+    last_sync_error = serializers.SerializerMethodField()
+    error_count = serializers.SerializerMethodField()
+    sync_interval = serializers.SerializerMethodField()
+
+    class Meta:
+        model = models.Channel
+        fields = [
+            "id",
+            "name",
+            "type",
+            "caldav_path",
+            "is_active",
+            "source_url",
+            "last_sync_at",
+            "last_sync_status",
+            "last_sync_error",
+            "error_count",
+            "sync_interval",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = fields
+
+    def get_source_url(self, obj) -> str:
+        return obj.settings.get("source_url", "")
+
+    def get_last_sync_at(self, obj) -> str | None:
+        return obj.settings.get("last_sync_at")
+
+    def get_last_sync_status(self, obj) -> str:
+        return obj.settings.get("last_sync_status", "pending")
+
+    def get_last_sync_error(self, obj) -> str:
+        return obj.settings.get("last_sync_error", "")
+
+    def get_error_count(self, obj) -> int:
+        return obj.settings.get("error_count", 0)
+
+    def get_sync_interval(self, obj) -> int:
+        return obj.settings.get("sync_interval", 300)
+
+
+class ChannelSubscriptionCreateSerializer(serializers.Serializer):
+    """Write serializer for creating subscription channels."""
+
+    name = serializers.CharField(max_length=255)
+    source_url = serializers.CharField(max_length=2048)
+    color = serializers.CharField(max_length=50, required=False, default="")
+
+    def validate_source_url(self, value):
+        """Validate and normalize the source URL."""
+        from core.services.url_validation import (  # noqa: PLC0415  # pylint: disable=C0415
+            URLValidationError,
+            validate_subscription_url,
+        )
+
+        try:
+            return validate_subscription_url(value)
+        except URLValidationError as exc:
+            raise serializers.ValidationError(str(exc)) from exc
+
+
+class ChannelSubscriptionUpdateSerializer(serializers.Serializer):
+    """Write serializer for updating subscription channels."""
+
+    name = serializers.CharField(max_length=255, required=False)
+    source_url = serializers.CharField(max_length=2048, required=False)
+    color = serializers.CharField(max_length=50, required=False)
+
+    def validate_source_url(self, value):
+        """Validate and normalize the source URL."""
+        from core.services.url_validation import (  # noqa: PLC0415  # pylint: disable=C0415
+            URLValidationError,
+            validate_subscription_url,
+        )
+
+        try:
+            return validate_subscription_url(value)
+        except URLValidationError as exc:
+            raise serializers.ValidationError(str(exc)) from exc
 
 
 class ChannelWithTokenSerializer(ChannelSerializer):

--- a/src/backend/core/api/viewsets_caldav.py
+++ b/src/backend/core/api/viewsets_caldav.py
@@ -16,7 +16,11 @@ import requests
 
 from core.entitlements import EntitlementsUnavailableError, get_user_entitlements
 from core.models import Channel
-from core.services.caldav_service import CalDAVHTTPClient, validate_caldav_proxy_path
+from core.services.caldav_service import (
+    CalDAVHTTPClient,
+    normalize_caldav_path,
+    validate_caldav_proxy_path,
+)
 from core.services.calendar_invitation_service import calendar_invitation_service
 
 logger = logging.getLogger(__name__)
@@ -113,16 +117,13 @@ class CalDAVProxyView(View):
         return False
 
     @staticmethod
-    def _check_subscription_readonly(user, path, method):
+    def _check_subscription_readonly(user, path, method):  # pylint: disable=unused-argument
         """Block write operations on calendars owned by ical-subscription channels.
 
         Returns an HttpResponse(403) if the path belongs to a subscription
-        calendar, None otherwise.
+        calendar, None otherwise. ``method`` is accepted for call-site
+        symmetry but not consulted — every write verb is equally blocked.
         """
-        from core.services.caldav_service import (  # noqa: PLC0415
-            normalize_caldav_path,
-        )
-
         full_path = "/" + path.lstrip("/") if path else "/"
         normalized = normalize_caldav_path(full_path)
 
@@ -130,13 +131,19 @@ class CalDAVProxyView(View):
         # The path could be /calendars/users/email/cal-uuid/event.ics
         # We need to match the calendar prefix
         # Note: no is_active filter — stopped subscriptions must stay read-only
-        subscription_paths = Channel.objects.filter(
-            user=user,
-            type="ical-subscription",
-        ).values_list("caldav_path", flat=True)
+        subscription_paths = (
+            Channel.objects.filter(
+                user=user,
+                type="ical-subscription",
+            )
+            .exclude(caldav_path__isnull=True)
+            .exclude(caldav_path="")
+            .values_list("caldav_path", flat=True)
+        )
 
         for sub_path in subscription_paths:
-            if normalized.startswith(sub_path) or full_path.startswith(sub_path):
+            normalized_sub = normalize_caldav_path(sub_path)
+            if normalized.startswith(normalized_sub):
                 return HttpResponse(
                     status=403,
                     content="Cannot modify events in a subscription calendar",

--- a/src/backend/core/api/viewsets_caldav.py
+++ b/src/backend/core/api/viewsets_caldav.py
@@ -113,6 +113,38 @@ class CalDAVProxyView(View):
         return False
 
     @staticmethod
+    def _check_subscription_readonly(user, path, method):
+        """Block write operations on calendars owned by ical-subscription channels.
+
+        Returns an HttpResponse(403) if the path belongs to a subscription
+        calendar, None otherwise.
+        """
+        from core.services.caldav_service import (  # noqa: PLC0415
+            normalize_caldav_path,
+        )
+
+        full_path = "/" + path.lstrip("/") if path else "/"
+        normalized = normalize_caldav_path(full_path)
+
+        # Check if any subscription channel owns this calendar path
+        # The path could be /calendars/users/email/cal-uuid/event.ics
+        # We need to match the calendar prefix
+        # Note: no is_active filter — stopped subscriptions must stay read-only
+        subscription_paths = Channel.objects.filter(
+            user=user,
+            type="ical-subscription",
+        ).values_list("caldav_path", flat=True)
+
+        for sub_path in subscription_paths:
+            if normalized.startswith(sub_path) or full_path.startswith(sub_path):
+                return HttpResponse(
+                    status=403,
+                    content="Cannot modify events in a subscription calendar",
+                )
+
+        return None
+
+    @staticmethod
     def _check_entitlements_for_creation(user):
         """Check if user is entitled to create calendars.
 
@@ -169,6 +201,14 @@ class CalDAVProxyView(View):
         # Check entitlements for calendar creation (all auth methods)
         if request.method in ("MKCALENDAR", "MKCOL"):
             if denied := self._check_entitlements_for_creation(effective_user):
+                return denied
+
+        # Block write operations on subscription calendars
+        # Allow only read methods; block PUT, DELETE, MOVE, PROPPATCH, POST
+        if request.method not in self.READER_METHODS:
+            if denied := self._check_subscription_readonly(
+                effective_user, kwargs.get("path", ""), request.method
+            ):
                 return denied
 
         # Build the CalDAV server URL

--- a/src/backend/core/api/viewsets_channels.py
+++ b/src/backend/core/api/viewsets_channels.py
@@ -2,6 +2,10 @@
 
 import logging
 import secrets
+from xml.sax.saxutils import escape as xml_escape
+
+from django.conf import settings
+from django.utils import timezone
 
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
@@ -10,10 +14,14 @@ from rest_framework.response import Response
 
 from core import models
 from core.api import serializers
-from core.services.caldav_service import verify_caldav_access
+from core.services.caldav_service import CalDAVClient, verify_caldav_access
 from core.services.channel_event_service import ChannelEventService
+from core.services.url_validation import URLValidationError, fetch_ics
 
 logger = logging.getLogger(__name__)
+
+# Custom property namespace for subscription source
+SUBSCRIPTION_SOURCE_PROP = "{http://lasuite.numerique.gouv.fr/ns/}subscription-source"
 
 
 class ChannelViewSet(viewsets.GenericViewSet):
@@ -41,7 +49,11 @@ class ChannelViewSet(viewsets.GenericViewSet):
         channel_type = request.query_params.get("type")
         if channel_type:
             queryset = queryset.filter(type=channel_type)
-        serializer = self.get_serializer(queryset, many=True)
+
+        if channel_type == "ical-subscription":
+            serializer = serializers.ChannelSubscriptionSerializer(queryset, many=True)
+        else:
+            serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
     def create(self, request):
@@ -49,7 +61,13 @@ class ChannelViewSet(viewsets.GenericViewSet):
 
         For type="ical-feed", returns an existing channel if one already
         exists for the same user + caldav_path (get-or-create semantics).
+        For type="ical-subscription", creates a SabreDAV calendar and
+        enqueues an initial sync task.
         """
+        # Dispatch to subscription-specific flow
+        if request.data.get("type") == "ical-subscription":
+            return self._create_subscription(request)
+
         create_serializer = serializers.ChannelCreateSerializer(data=request.data)
         create_serializer.is_valid(raise_exception=True)
         data = create_serializer.validated_data
@@ -105,6 +123,277 @@ class ChannelViewSet(viewsets.GenericViewSet):
         )
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
+    def _create_subscription(self, request):
+        """Create an ical-subscription channel with a SabreDAV calendar."""
+        # Enforce per-user subscription limit
+        current_count = models.Channel.objects.filter(
+            user=request.user, type="ical-subscription"
+        ).count()
+        if current_count >= settings.MAX_SUBSCRIPTIONS_PER_USER:
+            return Response(
+                {
+                    "detail": (
+                        f"Maximum number of subscriptions reached"
+                        f" ({settings.MAX_SUBSCRIPTIONS_PER_USER})."
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        sub_serializer = serializers.ChannelSubscriptionCreateSerializer(
+            data=request.data
+        )
+        sub_serializer.is_valid(raise_exception=True)
+        data = sub_serializer.validated_data
+
+        source_url = data["source_url"]
+        name = data["name"]
+
+        # Test fetch to verify URL works
+        try:
+            _status_code, ics_data, etag, last_modified = fetch_ics(source_url)
+        except URLValidationError as exc:
+            return Response(
+                {"source_url": [str(exc)]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if not ics_data:
+            return Response(
+                {"source_url": ["URL did not return calendar data"]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Create SabreDAV calendar
+        caldav_client = CalDAVClient()
+        try:
+            caldav_path = caldav_client.create_calendar(
+                request.user, calendar_name=name
+            )
+        except Exception:
+            logger.exception("Failed to create SabreDAV calendar for subscription")
+            return Response(
+                {"detail": "Failed to create calendar"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        # Set custom properties via PROPPATCH (subscription-source + color)
+        color = data.get("color", "")
+        try:
+            http = caldav_client._http  # noqa: SLF001
+            color_prop = ""
+            if color:
+                color_prop = (
+                    f"<a:calendar-color xmlns:a="
+                    f'"http://apple.com/ns/ical/">'
+                    f"{xml_escape(color)}</a:calendar-color>"
+                )
+            proppatch_body = (
+                '<?xml version="1.0" encoding="UTF-8"?>'
+                '<d:propertyupdate xmlns:d="DAV:" '
+                'xmlns:ls="http://lasuite.numerique.gouv.fr/ns/">'
+                "<d:set><d:prop>"
+                f"<ls:subscription-source>{xml_escape(source_url)}</ls:subscription-source>"
+                f"{color_prop}"
+                "</d:prop></d:set>"
+                "</d:propertyupdate>"
+            )
+            http.request(
+                "PROPPATCH",
+                request.user,
+                caldav_path,
+                data=proppatch_body.encode("utf-8"),
+                content_type="application/xml; charset=utf-8",
+            )
+        except Exception:
+            logger.exception("Failed to set subscription-source property")
+            # Non-fatal: the channel settings still track the source URL
+
+        # Create channel
+        channel = models.Channel(
+            name=name,
+            type="ical-subscription",
+            user=request.user,
+            caldav_path=caldav_path,
+            organization=request.user.organization,
+            settings={
+                "source_url": source_url,
+                "sync_interval": settings.SUBSCRIPTION_SYNC_INTERVAL,
+                "last_sync_status": "pending",
+                "last_sync_error": "",
+                "error_count": 0,
+                "etag": "",
+                "last_modified": "",
+            },
+        )
+        try:
+            channel.save()
+        except Exception:
+            logger.exception("Failed to save channel, cleaning up SabreDAV calendar")
+            try:
+                caldav_client._http.request(  # noqa: SLF001
+                    "DELETE", request.user, caldav_path
+                )
+            except Exception:
+                logger.exception("Failed to clean up SabreDAV calendar %s", caldav_path)
+            raise
+
+        # Sync events immediately using the ICS data we already fetched
+        try:
+            from core.services.subscription_sync_service import (  # noqa: PLC0415  # pylint: disable=C0415
+                SubscriptionSyncService,
+            )
+
+            service = SubscriptionSyncService()
+            service.sync_events(request.user, caldav_path, ics_data)
+            channel.settings["last_sync_status"] = "ok"
+            channel.settings["last_sync_at"] = timezone.now().isoformat()
+            channel.settings["etag"] = etag
+            channel.settings["last_modified"] = last_modified
+            channel.save(update_fields=["settings", "updated_at"])
+        except Exception:
+            logger.exception("Initial sync failed for channel %s", channel.pk)
+
+        serializer = serializers.ChannelSubscriptionSerializer(channel)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    def partial_update(self, request, pk=None):
+        """Update a subscription channel (name and/or source_url)."""
+        channel = self._get_owned_channel(pk)
+        if channel is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        if channel.type != "ical-subscription":
+            return Response(
+                {"detail": "Only subscription channels can be updated."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        update_serializer = serializers.ChannelSubscriptionUpdateSerializer(
+            data=request.data
+        )
+        update_serializer.is_valid(raise_exception=True)
+        data = update_serializer.validated_data
+
+        if "name" in data:
+            channel.name = data["name"]
+
+        new_source_url = data.get("source_url")
+        ics_data = None
+        new_etag = ""
+        new_last_modified = ""
+        if new_source_url and new_source_url != channel.settings.get("source_url"):
+            # Validate the new URL by fetching it (keep the data for immediate sync)
+            try:
+                _status_code, ics_data, new_etag, new_last_modified = fetch_ics(
+                    new_source_url
+                )
+            except URLValidationError as exc:
+                return Response(
+                    {"source_url": [str(exc)]},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            channel.settings["source_url"] = new_source_url
+            channel.settings["etag"] = ""
+            channel.settings["last_modified"] = ""
+            channel.settings["error_count"] = 0
+            channel.settings["last_sync_status"] = "pending"
+            channel.settings["last_sync_error"] = ""
+
+            # Purge existing events before syncing from new source
+            try:
+                from core.services.subscription_sync_service import (  # noqa: PLC0415
+                    SubscriptionSyncService,
+                )
+
+                SubscriptionSyncService().purge_events(
+                    request.user, channel.caldav_path
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to purge events for channel %s on URL change",
+                    channel.pk,
+                )
+
+            # Update WebDAV property
+            try:
+                http = CalDAVClient()._http  # noqa: SLF001
+                proppatch_body = (
+                    '<?xml version="1.0" encoding="UTF-8"?>'
+                    '<d:propertyupdate xmlns:d="DAV:" '
+                    'xmlns:ls="http://lasuite.numerique.gouv.fr/ns/">'
+                    "<d:set><d:prop>"
+                    "<ls:subscription-source>"
+                    f"{xml_escape(new_source_url)}"
+                    "</ls:subscription-source>"
+                    "</d:prop></d:set>"
+                    "</d:propertyupdate>"
+                )
+                http.request(
+                    "PROPPATCH",
+                    request.user,
+                    channel.caldav_path,
+                    data=proppatch_body.encode("utf-8"),
+                    content_type="application/xml; charset=utf-8",
+                )
+            except Exception:
+                logger.exception("Failed to update subscription-source property")
+
+            # Sync immediately using the ICS data we already fetched
+            if ics_data:
+                try:
+                    from core.services.subscription_sync_service import (  # noqa: PLC0415
+                        SubscriptionSyncService,
+                    )
+
+                    service = SubscriptionSyncService()
+                    service.sync_events(request.user, channel.caldav_path, ics_data)
+                    channel.settings["last_sync_status"] = "ok"
+                    channel.settings["last_sync_at"] = timezone.now().isoformat()
+                    channel.settings["etag"] = new_etag
+                    channel.settings["last_modified"] = new_last_modified
+                except Exception:
+                    logger.exception(
+                        "Immediate sync failed after URL update for channel %s",
+                        channel.pk,
+                    )
+
+        # Update CalDAV properties (displayname + color) via PROPPATCH
+        new_color = data.get("color")
+        new_name = data.get("name")
+        if (new_color or new_name) and channel.caldav_path:
+            props = ""
+            if new_name:
+                props += f"<d:displayname>{xml_escape(new_name)}</d:displayname>"
+            if new_color:
+                props += (
+                    f'<a:calendar-color xmlns:a="http://apple.com/ns/ical/">'
+                    f"{xml_escape(new_color)}</a:calendar-color>"
+                )
+            try:
+                http = CalDAVClient()._http  # noqa: SLF001
+                proppatch = (
+                    '<?xml version="1.0" encoding="UTF-8"?>'
+                    '<d:propertyupdate xmlns:d="DAV:">'
+                    f"<d:set><d:prop>{props}</d:prop></d:set>"
+                    "</d:propertyupdate>"
+                )
+                http.request(
+                    "PROPPATCH",
+                    request.user,
+                    channel.caldav_path,
+                    data=proppatch.encode("utf-8"),
+                    content_type="application/xml; charset=utf-8",
+                )
+            except Exception:
+                logger.exception("Failed to update CalDAV calendar properties")
+
+        channel.save(update_fields=["name", "settings", "updated_at"])
+
+        serializer = serializers.ChannelSubscriptionSerializer(channel)
+        return Response(serializer.data)
+
     def retrieve(self, request, pk=None):
         """Retrieve a channel (without token)."""
         channel = self._get_owned_channel(pk)
@@ -114,12 +403,62 @@ class ChannelViewSet(viewsets.GenericViewSet):
         return Response(serializer.data)
 
     def destroy(self, request, pk=None):
-        """Delete a channel."""
+        """Delete a channel.
+
+        For ical-subscription channels, also deletes the SabreDAV calendar.
+        """
         channel = self._get_owned_channel(pk)
         if channel is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
+
+        # Clean up SabreDAV calendar for subscriptions
+        if channel.type == "ical-subscription" and channel.caldav_path:
+            try:
+                http = CalDAVClient()._http  # noqa: SLF001
+                http.request("DELETE", request.user, channel.caldav_path)
+            except Exception:
+                logger.exception(
+                    "Failed to delete SabreDAV calendar %s for subscription %s",
+                    channel.caldav_path,
+                    channel.pk,
+                )
+                # Continue with channel deletion anyway
+
         channel.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @action(detail=True, methods=["post"], url_path="reactivate")
+    def reactivate(self, request, pk=None):
+        """Reactivate a stopped subscription channel."""
+        channel = self._get_owned_channel(pk)
+        if channel is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        if channel.type != "ical-subscription":
+            return Response(
+                {"detail": "Only subscription channels can be reactivated."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        channel.is_active = True
+        channel.settings["error_count"] = 0
+        channel.settings["last_sync_status"] = "pending"
+        channel.settings["last_sync_error"] = ""
+        channel.save(update_fields=["is_active", "settings", "updated_at"])
+
+        # Enqueue immediate sync
+        try:
+            from core.tasks import sync_one_subscription  # noqa: PLC0415
+
+            sync_one_subscription.send(str(channel.pk))
+        except Exception:
+            logger.exception(
+                "Failed to enqueue sync after reactivation for channel %s",
+                channel.pk,
+            )
+
+        serializer = serializers.ChannelSubscriptionSerializer(channel)
+        return Response(serializer.data)
 
     @action(detail=True, methods=["post"], url_path="regenerate-token")
     def regenerate_token(self, request, pk=None):

--- a/src/backend/core/api/viewsets_channels.py
+++ b/src/backend/core/api/viewsets_channels.py
@@ -1,10 +1,14 @@
 """Channel API for managing integration tokens."""
 
+# pylint: disable=broad-exception-caught,import-outside-toplevel,protected-access
+
 import logging
 import secrets
 from xml.sax.saxutils import escape as xml_escape
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.db import transaction
 from django.utils import timezone
 
 from rest_framework import status, viewsets
@@ -22,6 +26,12 @@ logger = logging.getLogger(__name__)
 
 # Custom property namespace for subscription source
 SUBSCRIPTION_SOURCE_PROP = "{http://lasuite.numerique.gouv.fr/ns/}subscription-source"
+
+
+class _SubscriptionQuotaExceeded(Exception):
+    """Marker exception raised inside the subscription-create transaction
+    when the per-user quota is already reached, so the atomic block can
+    roll back any intermediate state before the view returns a 400."""
 
 
 class ChannelViewSet(viewsets.GenericViewSet):
@@ -123,9 +133,12 @@ class ChannelViewSet(viewsets.GenericViewSet):
         )
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-    def _create_subscription(self, request):
+    def _create_subscription(self, request):  # noqa: PLR0912, PLR0915  # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         """Create an ical-subscription channel with a SabreDAV calendar."""
-        # Enforce per-user subscription limit
+        # Fast-path check: fail early on obviously-over-quota requests
+        # so we don't waste a network fetch. The authoritative atomic
+        # re-check happens later inside transaction.atomic() to prevent
+        # concurrent POSTs from racing past this point.
         current_count = models.Channel.objects.filter(
             user=request.user, type="ical-subscription"
         ).count()
@@ -209,25 +222,55 @@ class ChannelViewSet(viewsets.GenericViewSet):
             logger.exception("Failed to set subscription-source property")
             # Non-fatal: the channel settings still track the source URL
 
-        # Create channel
-        channel = models.Channel(
-            name=name,
-            type="ical-subscription",
-            user=request.user,
-            caldav_path=caldav_path,
-            organization=request.user.organization,
-            settings={
-                "source_url": source_url,
-                "sync_interval": settings.SUBSCRIPTION_SYNC_INTERVAL,
-                "last_sync_status": "pending",
-                "last_sync_error": "",
-                "error_count": 0,
-                "etag": "",
-                "last_modified": "",
-            },
-        )
+        # Atomically enforce the per-user quota and persist the channel
+        # so concurrent POSTs can't both pass the count check. The
+        # select_for_update on the user row serializes subscription
+        # creation per user.
+        user_model = get_user_model()
         try:
-            channel.save()
+            with transaction.atomic():
+                user_locked = user_model.objects.select_for_update().get(
+                    pk=request.user.pk
+                )
+                current_count = models.Channel.objects.filter(
+                    user=user_locked, type="ical-subscription"
+                ).count()
+                if current_count >= settings.MAX_SUBSCRIPTIONS_PER_USER:
+                    raise _SubscriptionQuotaExceeded()
+
+                channel = models.Channel(
+                    name=name,
+                    type="ical-subscription",
+                    user=request.user,
+                    caldav_path=caldav_path,
+                    organization=request.user.organization,
+                    settings={
+                        "source_url": source_url,
+                        "sync_interval": settings.SUBSCRIPTION_SYNC_INTERVAL,
+                        "last_sync_status": "pending",
+                        "last_sync_error": "",
+                        "error_count": 0,
+                        "etag": "",
+                        "last_modified": "",
+                    },
+                )
+                channel.save()
+        except _SubscriptionQuotaExceeded:
+            try:
+                caldav_client._http.request(  # noqa: SLF001
+                    "DELETE", request.user, caldav_path
+                )
+            except Exception:
+                logger.exception("Failed to clean up SabreDAV calendar %s", caldav_path)
+            return Response(
+                {
+                    "detail": (
+                        f"Maximum number of subscriptions reached"
+                        f" ({settings.MAX_SUBSCRIPTIONS_PER_USER})."
+                    )
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except Exception:
             logger.exception("Failed to save channel, cleaning up SabreDAV calendar")
             try:
@@ -240,24 +283,40 @@ class ChannelViewSet(viewsets.GenericViewSet):
 
         # Sync events immediately using the ICS data we already fetched
         try:
-            from core.services.subscription_sync_service import (  # noqa: PLC0415  # pylint: disable=C0415
+            from core.services.subscription_sync_service import (  # noqa: PLC0415
                 SubscriptionSyncService,
             )
 
             service = SubscriptionSyncService()
-            service.sync_events(request.user, caldav_path, ics_data)
-            channel.settings["last_sync_status"] = "ok"
+            sync_result = service.sync_events(
+                request.user, caldav_path, ics_data, channel_id=str(channel.pk)
+            )
             channel.settings["last_sync_at"] = timezone.now().isoformat()
             channel.settings["etag"] = etag
             channel.settings["last_modified"] = last_modified
+            if sync_result.errors:
+                channel.settings["last_sync_status"] = "error"
+                channel.settings["last_sync_error"] = (
+                    f"{len(sync_result.errors)} event error(s)"
+                )
+                channel.settings["error_count"] = 1
+            else:
+                channel.settings["last_sync_status"] = "ok"
+                channel.settings["last_sync_error"] = ""
+                channel.settings["error_count"] = 0
             channel.save(update_fields=["settings", "updated_at"])
-        except Exception:
+        except Exception as exc:
             logger.exception("Initial sync failed for channel %s", channel.pk)
+            channel.settings["last_sync_status"] = "error"
+            channel.settings["last_sync_error"] = str(exc)[:500]
+            channel.settings["error_count"] = 1
+            channel.settings["last_sync_at"] = timezone.now().isoformat()
+            channel.save(update_fields=["settings", "updated_at"])
 
         serializer = serializers.ChannelSubscriptionSerializer(channel)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-    def partial_update(self, request, pk=None):
+    def partial_update(self, request, pk=None):  # noqa: PLR0912, PLR0915  # pylint: disable=too-many-branches,too-many-locals,too-many-statements
         """Update a subscription channel (name and/or source_url)."""
         channel = self._get_owned_channel(pk)
         if channel is None:
@@ -348,16 +407,34 @@ class ChannelViewSet(viewsets.GenericViewSet):
                     )
 
                     service = SubscriptionSyncService()
-                    service.sync_events(request.user, channel.caldav_path, ics_data)
-                    channel.settings["last_sync_status"] = "ok"
+                    sync_result = service.sync_events(
+                        request.user,
+                        channel.caldav_path,
+                        ics_data,
+                        channel_id=str(channel.pk),
+                    )
                     channel.settings["last_sync_at"] = timezone.now().isoformat()
                     channel.settings["etag"] = new_etag
                     channel.settings["last_modified"] = new_last_modified
-                except Exception:
+                    if sync_result.errors:
+                        channel.settings["last_sync_status"] = "error"
+                        channel.settings["last_sync_error"] = (
+                            f"{len(sync_result.errors)} event error(s)"
+                        )
+                        channel.settings["error_count"] = 1
+                    else:
+                        channel.settings["last_sync_status"] = "ok"
+                        channel.settings["last_sync_error"] = ""
+                        channel.settings["error_count"] = 0
+                except Exception as exc:
                     logger.exception(
                         "Immediate sync failed after URL update for channel %s",
                         channel.pk,
                     )
+                    channel.settings["last_sync_status"] = "error"
+                    channel.settings["last_sync_error"] = str(exc)[:500]
+                    channel.settings["error_count"] = 1
+                    channel.settings["last_sync_at"] = timezone.now().isoformat()
 
         # Update CalDAV properties (displayname + color) via PROPPATCH
         new_color = data.get("color")

--- a/src/backend/core/factories.py
+++ b/src/backend/core/factories.py
@@ -64,3 +64,24 @@ class ICalFeedChannelFactory(ChannelFactory):
     settings = factory.LazyAttribute(
         lambda obj: {"role": "reader", "calendar_name": fake.sentence(nb_words=3)}
     )
+
+
+class ICalSubscriptionChannelFactory(ChannelFactory):
+    """A factory to create ical-subscription channels."""
+
+    type = "ical-subscription"
+    caldav_path = factory.LazyAttribute(
+        lambda obj: f"/calendars/users/{obj.user.email}/{fake.uuid4()}/"
+    )
+    settings = factory.LazyAttribute(
+        lambda obj: {
+            "source_url": f"https://example.com/{fake.uuid4()}.ics",
+            "sync_interval": 300,
+            "last_sync_status": "ok",
+            "last_sync_error": "",
+            "error_count": 0,
+            "etag": "",
+            "last_modified": "",
+        }
+    )
+    encrypted_settings = factory.LazyFunction(dict)

--- a/src/backend/core/management/commands/run_subscription_scheduler.py
+++ b/src/backend/core/management/commands/run_subscription_scheduler.py
@@ -1,0 +1,47 @@
+"""Management command to run the subscription sync scheduler.
+
+Dispatches sync_all_subscriptions every 60 seconds (configurable via
+SUBSCRIPTION_SCHEDULER_INTERVAL env var). Designed to run as a
+long-lived process in a dedicated Docker service.
+"""
+
+import logging
+import os
+import signal
+import time
+
+from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
+
+SCHEDULER_INTERVAL = int(os.environ.get("SUBSCRIPTION_SCHEDULER_INTERVAL", "60"))
+
+
+class Command(BaseCommand):
+    help = "Run the subscription sync scheduler (dispatches sync tasks every 60s)"
+
+    def handle(self, *args, **options):
+        from core.tasks import sync_all_subscriptions  # noqa: PLC0415
+
+        running = True
+
+        def _shutdown(signum, frame):
+            nonlocal running
+            running = False
+            logger.info("Subscription scheduler received signal %s, shutting down...", signum)
+
+        signal.signal(signal.SIGTERM, _shutdown)
+        signal.signal(signal.SIGINT, _shutdown)
+
+        self.stdout.write("Starting subscription scheduler...")
+        logger.info("Subscription scheduler started (interval=%ds)", SCHEDULER_INTERVAL)
+
+        while running:
+            try:
+                sync_all_subscriptions.send()
+            except Exception:
+                logger.exception("Failed to dispatch sync_all_subscriptions")
+
+            time.sleep(SCHEDULER_INTERVAL)
+
+        logger.info("Subscription scheduler stopped.")

--- a/src/backend/core/management/commands/run_subscription_scheduler.py
+++ b/src/backend/core/management/commands/run_subscription_scheduler.py
@@ -5,6 +5,8 @@ SUBSCRIPTION_SCHEDULER_INTERVAL env var). Designed to run as a
 long-lived process in a dedicated Docker service.
 """
 
+# pylint: disable=import-outside-toplevel
+
 import logging
 import os
 import signal
@@ -14,21 +16,40 @@ from django.core.management.base import BaseCommand
 
 logger = logging.getLogger(__name__)
 
-SCHEDULER_INTERVAL = int(os.environ.get("SUBSCRIPTION_SCHEDULER_INTERVAL", "60"))
+
+def _get_scheduler_interval() -> int:
+    raw = os.environ.get("SUBSCRIPTION_SCHEDULER_INTERVAL", "60")
+    try:
+        interval = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid SUBSCRIPTION_SCHEDULER_INTERVAL=%r, falling back to 60s",
+            raw,
+        )
+        return 60
+    return max(interval, 1)
+
+
+SCHEDULER_INTERVAL = _get_scheduler_interval()
 
 
 class Command(BaseCommand):
+    """Run the subscription sync scheduler loop."""
+
     help = "Run the subscription sync scheduler (dispatches sync tasks every 60s)"
 
     def handle(self, *args, **options):
+        # Local import avoids loading Dramatiq at Django startup.
         from core.tasks import sync_all_subscriptions  # noqa: PLC0415
 
         running = True
 
-        def _shutdown(signum, frame):
+        def _shutdown(signum, _frame):
             nonlocal running
             running = False
-            logger.info("Subscription scheduler received signal %s, shutting down...", signum)
+            logger.info(
+                "Subscription scheduler received signal %s, shutting down...", signum
+            )
 
         signal.signal(signal.SIGTERM, _shutdown)
         signal.signal(signal.SIGINT, _shutdown)
@@ -39,7 +60,7 @@ class Command(BaseCommand):
         while running:
             try:
                 sync_all_subscriptions.send()
-            except Exception:
+            except Exception:  # pylint: disable=broad-exception-caught
                 logger.exception("Failed to dispatch sync_all_subscriptions")
 
             time.sleep(SCHEDULER_INTERVAL)

--- a/src/backend/core/management/commands/sync_mailbox_acls.py
+++ b/src/backend/core/management/commands/sync_mailbox_acls.py
@@ -24,6 +24,8 @@ User = get_user_model()
 
 
 class Command(BaseCommand):
+    """Sync Messages mailbox ACLs onto their corresponding CalDAV calendars."""
+
     help = "Sync Messages mailbox ACLs to CalDAV shares."
 
     def add_arguments(self, parser):

--- a/src/backend/core/services/subscription_sync_service.py
+++ b/src/backend/core/services/subscription_sync_service.py
@@ -5,9 +5,13 @@ existing events in the SabreDAV calendar, then creates/updates/deletes
 as needed.
 """
 
+# pylint: disable=broad-exception-caught,import-outside-toplevel,protected-access
+
 import logging
 import re
+import secrets
 import urllib.parse
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 
 from django.core.cache import cache
@@ -22,6 +26,27 @@ logger = logging.getLogger(__name__)
 
 MAX_CONSECUTIVE_ERRORS = 3
 SYNC_LOCK_TIMEOUT = 120  # seconds
+
+
+@contextmanager
+def _channel_sync_lock(channel_id: str):
+    """Tokenized per-channel sync lock.
+
+    Yields True if the lock was acquired, False if another worker already
+    holds it. Only the worker that wrote the lock token deletes it, so a
+    finally block running after the TTL expired cannot evict a second
+    worker's lease.
+    """
+    lock_key = f"sync_lock:{channel_id}"
+    token = secrets.token_hex(16)
+    acquired = cache.add(lock_key, token, timeout=SYNC_LOCK_TIMEOUT)
+    try:
+        yield acquired
+    finally:
+        if acquired and cache.get(lock_key) == token:
+            cache.delete(lock_key)
+
+
 # Reject UIDs containing path traversal characters or null bytes.
 # All other characters are percent-encoded when used in CalDAV paths.
 UNSAFE_UID_RE = re.compile(r"[/\\\x00]|\.\.")
@@ -36,6 +61,16 @@ class SyncResult:
     deleted: int = 0
     unchanged: int = 0
     errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _SyncContext:
+    """Per-sync state shared between the create/update/delete helpers."""
+
+    user: object
+    caldav_path: str
+    new_events: dict[str, str]
+    existing: dict[str, dict]
 
 
 class SubscriptionSyncService:
@@ -74,20 +109,15 @@ class SubscriptionSyncService:
 
         Returns True if sync completed (success or 304), False on error.
         """
-        from core.models import Channel  # noqa: PLC0415
-
-        lock_key = f"sync_lock:{channel_id}"
-        if not cache.add(lock_key, "1", timeout=SYNC_LOCK_TIMEOUT):
-            logger.info("Sync already running for channel %s, skipping", channel_id)
-            return True
-
-        try:
+        with _channel_sync_lock(channel_id) as acquired:
+            if not acquired:
+                logger.info("Sync already running for channel %s, skipping", channel_id)
+                return True
             return self._do_sync(channel_id)
-        finally:
-            cache.delete(lock_key)
 
     def _do_sync(self, channel_id: str) -> bool:
         """Inner sync logic (lock already held)."""
+        # Local import avoids a circular dependency with core.models.
         from core.models import Channel  # noqa: PLC0415
 
         try:
@@ -115,6 +145,8 @@ class SubscriptionSyncService:
         if status_code == 304:
             channel.settings["last_sync_at"] = now
             channel.settings["last_sync_status"] = "ok"
+            channel.settings["last_sync_error"] = ""
+            channel.settings["error_count"] = 0
             return self._save_channel(channel)
 
         # 200 — diff sync
@@ -130,9 +162,7 @@ class SubscriptionSyncService:
         channel.settings["last_sync_at"] = now
         if result.errors:
             channel.settings["last_sync_status"] = "ok"
-            channel.settings["last_sync_error"] = (
-                f"{len(result.errors)} event error(s)"
-            )
+            channel.settings["last_sync_error"] = f"{len(result.errors)} event error(s)"
         else:
             channel.settings["last_sync_status"] = "ok"
             channel.settings["last_sync_error"] = ""
@@ -173,8 +203,7 @@ class SubscriptionSyncService:
     @staticmethod
     def _save_channel(channel) -> bool:
         """Save channel settings, handling deletion race condition."""
-        from django.utils import timezone  # noqa: PLC0415
-
+        # Local import avoids a circular dependency with core.models.
         from core.models import Channel  # noqa: PLC0415
 
         fields = ["settings", "updated_at"]
@@ -192,31 +221,77 @@ class SubscriptionSyncService:
             channel.updated_at = timezone.now()
             channel.save(update_fields=fields)
             return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             logger.warning(
                 "Failed to save channel %s (likely deleted during sync)",
                 channel.pk,
             )
             return False
 
-    def sync_events(self, user, caldav_path: str, ics_data: bytes) -> SyncResult:
-        """Public entry point for syncing ICS data into a SabreDAV calendar."""
-        return self._sync_events(user, caldav_path, ics_data)
+    def sync_events(
+        self,
+        user,
+        caldav_path: str,
+        ics_data: bytes,
+        channel_id: str | None = None,
+    ) -> SyncResult:
+        """Public entry point for syncing ICS data into a SabreDAV calendar.
+
+        When ``channel_id`` is provided, acquires the same per-channel
+        lock used by :meth:`sync_channel` so request-thread syncs cannot
+        interleave SabreDAV writes with scheduler-driven syncs on the
+        same calendar.
+        """
+        if channel_id is None:
+            return self._sync_events(user, caldav_path, ics_data)
+
+        with _channel_sync_lock(channel_id) as acquired:
+            if not acquired:
+                # Another worker is already syncing this channel — skip
+                # to avoid interleaving. The caller can retry later.
+                logger.info(
+                    "Sync already running for channel %s, skipping sync_events",
+                    channel_id,
+                )
+                return SyncResult()
+            return self._sync_events(user, caldav_path, ics_data)
 
     def _sync_events(self, user, caldav_path: str, ics_data: bytes) -> SyncResult:
         """Diff-sync events from ICS data into a SabreDAV calendar."""
         result = SyncResult()
 
-        # Parse new ICS
         new_events = self._parse_ics_events(ics_data)
         new_uids = set(new_events.keys())
 
-        # Get existing events from SabreDAV
+        existing = self._fetch_existing_events(user, caldav_path)
+        existing_uids = set(existing.keys())
+
+        # Guard against empty source wiping all events (server error / maintenance)
+        if not new_uids and existing_uids:
+            raise ValueError(
+                f"Source returned 0 events but calendar has {len(existing_uids)}"
+                " — refusing to delete all events (possible source error)"
+            )
+
+        ctx = _SyncContext(
+            user=user,
+            caldav_path=caldav_path,
+            new_events=new_events,
+            existing=existing,
+        )
+        self._create_events(ctx, new_uids - existing_uids, result)
+        self._update_events(ctx, new_uids & existing_uids, result)
+        self._delete_events(ctx, existing_uids - new_uids, result)
+
+        return result
+
+    def _fetch_existing_events(self, user, caldav_path: str) -> dict[str, dict]:
+        """Return ``{uid: {"href", "data"}}`` for events currently in SabreDAV."""
         client = self._http.get_dav_client(user)
         calendar_url = self._caldav._calendar_url(caldav_path)  # noqa: SLF001
         calendar = client.calendar(url=calendar_url)
 
-        existing = {}  # uid -> (href, data_hash)
+        existing: dict[str, dict] = {}
         try:
             for event in calendar.events():
                 uid = str(event.icalendar_component.get("uid", ""))
@@ -228,66 +303,72 @@ class SubscriptionSyncService:
         except Exception:
             logger.exception("Failed to list existing events in %s", caldav_path)
             raise
+        return existing
 
-        existing_uids = set(existing.keys())
-
-        # Guard against empty source wiping all events (server error / maintenance)
-        if not new_uids and existing_uids:
-            raise ValueError(
-                f"Source returned 0 events but calendar has {len(existing_uids)}"
-                " — refusing to delete all events (possible source error)"
-            )
-
-        # Create new events
-        for uid in new_uids - existing_uids:
+    def _create_events(
+        self,
+        ctx: _SyncContext,
+        uids_to_create: set[str],
+        result: SyncResult,
+    ) -> None:
+        for uid in uids_to_create:
             if UNSAFE_UID_RE.search(uid):
                 result.errors.append(f"Skipped {uid!r}: unsafe UID characters")
                 continue
             safe_uid = urllib.parse.quote(uid, safe="@._-")
             try:
                 success = self._http.put_event(
-                    user,
-                    f"{caldav_path}{safe_uid}.ics",
-                    new_events[uid],
+                    ctx.user,
+                    f"{ctx.caldav_path}{safe_uid}.ics",
+                    ctx.new_events[uid],
                 )
-                if success:
-                    result.created += 1
-                else:
-                    result.errors.append(f"Create {uid}: PUT rejected by server")
             except Exception as exc:  # noqa: BLE001
                 result.errors.append(f"Create {uid}: {exc}")
-
-        # Update modified events
-        for uid in new_uids & existing_uids:
-            # Compare raw ICS data to detect changes
-            if self._events_differ(existing[uid]["data"], new_events[uid]):
-                try:
-                    success = self._http.put_event(
-                        user,
-                        existing[uid]["href"],
-                        new_events[uid],
-                    )
-                    if success:
-                        result.updated += 1
-                    else:
-                        result.errors.append(f"Update {uid}: PUT rejected by server")
-                except Exception as exc:  # noqa: BLE001
-                    result.errors.append(f"Update {uid}: {exc}")
+                continue
+            if success:
+                result.created += 1
             else:
-                result.unchanged += 1
+                result.errors.append(f"Create {uid}: PUT rejected by server")
 
-        # Delete removed events
-        for uid in existing_uids - new_uids:
+    def _update_events(
+        self,
+        ctx: _SyncContext,
+        uids_to_check: set[str],
+        result: SyncResult,
+    ) -> None:
+        for uid in uids_to_check:
+            if not self._events_differ(ctx.existing[uid]["data"], ctx.new_events[uid]):
+                result.unchanged += 1
+                continue
             try:
-                self._caldav.delete_event(user, caldav_path, uid)
+                success = self._http.put_event(
+                    ctx.user,
+                    ctx.existing[uid]["href"],
+                    ctx.new_events[uid],
+                )
+            except Exception as exc:  # noqa: BLE001
+                result.errors.append(f"Update {uid}: {exc}")
+                continue
+            if success:
+                result.updated += 1
+            else:
+                result.errors.append(f"Update {uid}: PUT rejected by server")
+
+    def _delete_events(
+        self,
+        ctx: _SyncContext,
+        uids_to_delete: set[str],
+        result: SyncResult,
+    ) -> None:
+        for uid in uids_to_delete:
+            try:
+                self._caldav.delete_event(ctx.user, ctx.caldav_path, uid)
                 result.deleted += 1
             except ValueError:
                 # Event already deleted externally — desired state achieved
                 result.deleted += 1
             except Exception as exc:  # noqa: BLE001
                 result.errors.append(f"Delete {uid}: {exc}")
-
-        return result
 
     @staticmethod
     def _normalize_ics_encoding(ics_data: bytes) -> bytes:
@@ -380,13 +461,58 @@ class SubscriptionSyncService:
     VOLATILE_PROPS = {"DTSTAMP", "LAST-MODIFIED", "SEQUENCE", "CREATED"}
 
     @staticmethod
-    def _event_props(component) -> dict:
-        """Extract non-volatile properties from a VEVENT as a comparable dict."""
-        return {
-            k: str(v)
-            for k, v in component.items()
-            if k not in SubscriptionSyncService.VOLATILE_PROPS
-        }
+    def _serialize_property(value) -> tuple:
+        """Serialize a property value with its parameters for comparison.
+
+        Returns a tuple ``(serialized_value, sorted_params)`` so two
+        properties compare equal iff their value *and* parameter set
+        (e.g. ``ATTENDEE;PARTSTAT=ACCEPTED``) are identical.
+        """
+        params = getattr(value, "params", None) or {}
+        sorted_params = tuple(sorted((k, str(v)) for k, v in params.items()))
+        try:
+            serialized = value.to_ical()
+            if isinstance(serialized, bytes):
+                serialized = serialized.decode("utf-8", errors="replace")
+        except Exception:  # noqa: BLE001
+            serialized = str(value)
+        return serialized, sorted_params
+
+    @staticmethod
+    def _serialize_subcomponent(subcomponent) -> tuple:
+        """Serialize a subcomponent (e.g. VALARM) for comparison."""
+        name = getattr(subcomponent, "name", "")
+        props = tuple(
+            sorted(
+                (k, SubscriptionSyncService._serialize_property(v))
+                for k, v in subcomponent.items()
+                if k not in SubscriptionSyncService.VOLATILE_PROPS
+            )
+        )
+        return (name, props)
+
+    @staticmethod
+    def _event_props(component) -> tuple:
+        """Extract comparable representation of a VEVENT.
+
+        Includes property parameters (so ``ATTENDEE;PARTSTAT=ACCEPTED``
+        differs from ``ATTENDEE;PARTSTAT=DECLINED``) and subcomponents
+        like ``VALARM`` so alarm edits trigger an update.
+        """
+        props = tuple(
+            sorted(
+                (k, SubscriptionSyncService._serialize_property(v))
+                for k, v in component.items()
+                if k not in SubscriptionSyncService.VOLATILE_PROPS
+            )
+        )
+        subcomponents = tuple(
+            sorted(
+                SubscriptionSyncService._serialize_subcomponent(sub)
+                for sub in component.subcomponents
+            )
+        )
+        return (props, subcomponents)
 
     @staticmethod
     def _events_differ(existing_data: str, new_data: str) -> bool:
@@ -409,7 +535,9 @@ class SubscriptionSyncService:
             # Group by RECURRENCE-ID to handle reordered override instances
             def _keyed(events):
                 return {
-                    str(ev.get("RECURRENCE-ID", "")): SubscriptionSyncService._event_props(ev)
+                    str(
+                        ev.get("RECURRENCE-ID", "")
+                    ): SubscriptionSyncService._event_props(ev)
                     for ev in events
                 }
 

--- a/src/backend/core/services/subscription_sync_service.py
+++ b/src/backend/core/services/subscription_sync_service.py
@@ -1,0 +1,419 @@
+"""Service for syncing external calendar subscriptions.
+
+Implements diff-based sync: compares UIDs from the external ICS with
+existing events in the SabreDAV calendar, then creates/updates/deletes
+as needed.
+"""
+
+import logging
+import re
+import urllib.parse
+from dataclasses import dataclass, field
+
+from django.core.cache import cache
+from django.utils import timezone
+
+import icalendar
+
+from core.services.caldav_service import CalDAVClient, CalDAVHTTPClient
+from core.services.url_validation import URLValidationError, fetch_ics
+
+logger = logging.getLogger(__name__)
+
+MAX_CONSECUTIVE_ERRORS = 3
+SYNC_LOCK_TIMEOUT = 120  # seconds
+# Reject UIDs containing path traversal characters or null bytes.
+# All other characters are percent-encoded when used in CalDAV paths.
+UNSAFE_UID_RE = re.compile(r"[/\\\x00]|\.\.")
+
+
+@dataclass
+class SyncResult:
+    """Result of a subscription sync operation."""
+
+    created: int = 0
+    updated: int = 0
+    deleted: int = 0
+    unchanged: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+class SubscriptionSyncService:
+    """Syncs external ICS subscriptions into SabreDAV calendars."""
+
+    def __init__(self):
+        self._http = CalDAVHTTPClient()
+        self._caldav = CalDAVClient()
+
+    def purge_events(self, user, caldav_path: str) -> int:
+        """Delete all events from a SabreDAV calendar.
+
+        Returns the number of deleted events.
+        """
+        client = self._http.get_dav_client(user)
+        calendar_url = self._caldav._calendar_url(caldav_path)  # noqa: SLF001
+        calendar = client.calendar(url=calendar_url)
+
+        deleted = 0
+        for event in calendar.events():
+            uid = str(event.icalendar_component.get("uid", ""))
+            if uid:
+                try:
+                    self._caldav.delete_event(user, caldav_path, uid)
+                    deleted += 1
+                except Exception:  # noqa: BLE001
+                    logger.warning("Failed to delete event %s during purge", uid)
+        return deleted
+
+    def sync_channel(self, channel_id: str) -> bool:
+        """Sync a single subscription channel.
+
+        Acquires a Redis lock to prevent concurrent syncs on the same
+        channel. Handles 304/200/error cases and updates channel
+        settings accordingly.
+
+        Returns True if sync completed (success or 304), False on error.
+        """
+        from core.models import Channel  # noqa: PLC0415
+
+        lock_key = f"sync_lock:{channel_id}"
+        if not cache.add(lock_key, "1", timeout=SYNC_LOCK_TIMEOUT):
+            logger.info("Sync already running for channel %s, skipping", channel_id)
+            return True
+
+        try:
+            return self._do_sync(channel_id)
+        finally:
+            cache.delete(lock_key)
+
+    def _do_sync(self, channel_id: str) -> bool:
+        """Inner sync logic (lock already held)."""
+        from core.models import Channel  # noqa: PLC0415
+
+        try:
+            channel = Channel.objects.get(
+                pk=channel_id, type="ical-subscription", is_active=True
+            )
+        except Channel.DoesNotExist:
+            logger.warning("Channel %s not found or inactive", channel_id)
+            return False
+
+        source_url = channel.settings.get("source_url", "")
+        etag = channel.settings.get("etag", "")
+        last_modified = channel.settings.get("last_modified", "")
+
+        # Fetch ICS
+        try:
+            status_code, ics_data, new_etag, new_last_modified = fetch_ics(
+                source_url, etag=etag, last_modified=last_modified
+            )
+        except URLValidationError as exc:
+            return self._handle_error(channel, str(exc))
+
+        now = timezone.now().isoformat()
+
+        if status_code == 304:
+            channel.settings["last_sync_at"] = now
+            channel.settings["last_sync_status"] = "ok"
+            return self._save_channel(channel)
+
+        # 200 — diff sync
+        try:
+            result = self._sync_events(channel.user, channel.caldav_path, ics_data)
+        except Exception as exc:
+            logger.exception("Sync events failed for channel %s", channel_id)
+            return self._handle_error(channel, f"Sync failed: {exc}")
+
+        # Success — update channel settings
+        channel.settings["etag"] = new_etag
+        channel.settings["last_modified"] = new_last_modified
+        channel.settings["last_sync_at"] = now
+        if result.errors:
+            channel.settings["last_sync_status"] = "ok"
+            channel.settings["last_sync_error"] = (
+                f"{len(result.errors)} event error(s)"
+            )
+        else:
+            channel.settings["last_sync_status"] = "ok"
+            channel.settings["last_sync_error"] = ""
+        channel.settings["error_count"] = 0
+        if not self._save_channel(channel):
+            return False
+
+        logger.info(
+            "Synced channel %s: +%d ~%d -%d =%d errors=%d",
+            channel_id,
+            result.created,
+            result.updated,
+            result.deleted,
+            result.unchanged,
+            len(result.errors),
+        )
+        return True
+
+    def _handle_error(self, channel, error_msg: str) -> bool:
+        """Handle a sync error: increment count, auto-stop after 3."""
+        error_count = channel.settings.get("error_count", 0) + 1
+        channel.settings["error_count"] = error_count
+        channel.settings["last_sync_status"] = "error"
+        channel.settings["last_sync_error"] = error_msg[:500]
+        channel.settings["last_sync_at"] = timezone.now().isoformat()
+
+        if error_count >= MAX_CONSECUTIVE_ERRORS:
+            channel.is_active = False
+            logger.warning(
+                "Channel %s auto-stopped after %d consecutive errors",
+                channel.pk,
+                error_count,
+            )
+
+        self._save_channel(channel)
+        return False
+
+    @staticmethod
+    def _save_channel(channel) -> bool:
+        """Save channel settings, handling deletion race condition."""
+        from django.utils import timezone  # noqa: PLC0415
+
+        from core.models import Channel  # noqa: PLC0415
+
+        fields = ["settings", "updated_at"]
+        if not channel.is_active:
+            fields.append("is_active")
+        try:
+            # Re-check the channel still exists before saving
+            if not Channel.objects.filter(pk=channel.pk).exists():
+                logger.info(
+                    "Channel %s was deleted during sync, skipping save",
+                    channel.pk,
+                )
+                return False
+            # auto_now=True is not honoured with update_fields, set manually
+            channel.updated_at = timezone.now()
+            channel.save(update_fields=fields)
+            return True
+        except Exception:
+            logger.warning(
+                "Failed to save channel %s (likely deleted during sync)",
+                channel.pk,
+            )
+            return False
+
+    def sync_events(self, user, caldav_path: str, ics_data: bytes) -> SyncResult:
+        """Public entry point for syncing ICS data into a SabreDAV calendar."""
+        return self._sync_events(user, caldav_path, ics_data)
+
+    def _sync_events(self, user, caldav_path: str, ics_data: bytes) -> SyncResult:
+        """Diff-sync events from ICS data into a SabreDAV calendar."""
+        result = SyncResult()
+
+        # Parse new ICS
+        new_events = self._parse_ics_events(ics_data)
+        new_uids = set(new_events.keys())
+
+        # Get existing events from SabreDAV
+        client = self._http.get_dav_client(user)
+        calendar_url = self._caldav._calendar_url(caldav_path)  # noqa: SLF001
+        calendar = client.calendar(url=calendar_url)
+
+        existing = {}  # uid -> (href, data_hash)
+        try:
+            for event in calendar.events():
+                uid = str(event.icalendar_component.get("uid", ""))
+                if uid:
+                    existing[uid] = {
+                        "href": str(event.url.path),
+                        "data": event.data,
+                    }
+        except Exception:
+            logger.exception("Failed to list existing events in %s", caldav_path)
+            raise
+
+        existing_uids = set(existing.keys())
+
+        # Guard against empty source wiping all events (server error / maintenance)
+        if not new_uids and existing_uids:
+            raise ValueError(
+                f"Source returned 0 events but calendar has {len(existing_uids)}"
+                " — refusing to delete all events (possible source error)"
+            )
+
+        # Create new events
+        for uid in new_uids - existing_uids:
+            if UNSAFE_UID_RE.search(uid):
+                result.errors.append(f"Skipped {uid!r}: unsafe UID characters")
+                continue
+            safe_uid = urllib.parse.quote(uid, safe="@._-")
+            try:
+                success = self._http.put_event(
+                    user,
+                    f"{caldav_path}{safe_uid}.ics",
+                    new_events[uid],
+                )
+                if success:
+                    result.created += 1
+                else:
+                    result.errors.append(f"Create {uid}: PUT rejected by server")
+            except Exception as exc:  # noqa: BLE001
+                result.errors.append(f"Create {uid}: {exc}")
+
+        # Update modified events
+        for uid in new_uids & existing_uids:
+            # Compare raw ICS data to detect changes
+            if self._events_differ(existing[uid]["data"], new_events[uid]):
+                try:
+                    success = self._http.put_event(
+                        user,
+                        existing[uid]["href"],
+                        new_events[uid],
+                    )
+                    if success:
+                        result.updated += 1
+                    else:
+                        result.errors.append(f"Update {uid}: PUT rejected by server")
+                except Exception as exc:  # noqa: BLE001
+                    result.errors.append(f"Update {uid}: {exc}")
+            else:
+                result.unchanged += 1
+
+        # Delete removed events
+        for uid in existing_uids - new_uids:
+            try:
+                self._caldav.delete_event(user, caldav_path, uid)
+                result.deleted += 1
+            except ValueError:
+                # Event already deleted externally — desired state achieved
+                result.deleted += 1
+            except Exception as exc:  # noqa: BLE001
+                result.errors.append(f"Delete {uid}: {exc}")
+
+        return result
+
+    @staticmethod
+    def _normalize_ics_encoding(ics_data: bytes) -> bytes:
+        """Ensure ICS data is valid UTF-8.
+
+        Some legacy ICS producers use Latin-1 or Windows-1252 encoding.
+        Re-encode to UTF-8 if needed.
+        """
+        try:
+            ics_data.decode("utf-8")
+            return ics_data
+        except UnicodeDecodeError:
+            logger.warning("ICS data is not valid UTF-8, trying latin-1 fallback")
+            return ics_data.decode("latin-1").encode("utf-8")
+
+    @staticmethod
+    def _parse_ics_events(ics_data: bytes) -> dict[str, str]:
+        """Parse ICS data and return a dict of UID -> complete VCALENDAR string.
+
+        Each event is wrapped in its own VCALENDAR for individual PUT.
+        """
+        ics_data = SubscriptionSyncService._normalize_ics_encoding(ics_data)
+        cal = icalendar.Calendar.from_ical(ics_data)
+        events = {}
+
+        # Extract VTIMEZONE components to include with each event
+        timezones = []
+        for component in cal.walk():
+            if component.name == "VTIMEZONE":
+                timezones.append(component)
+
+        # Group VEVENTs by UID (recurring events may have override instances
+        # sharing the same UID, distinguished by RECURRENCE-ID)
+        grouped: dict[str, list] = {}
+        for component in cal.walk("VEVENT"):
+            uid = str(component.get("uid", ""))
+            if not uid:
+                continue
+            SubscriptionSyncService._cap_infinite_rrule(component)
+            grouped.setdefault(uid, []).append(component)
+
+        for uid, components in grouped.items():
+            single_cal = icalendar.Calendar()
+            single_cal.add("prodid", cal.get("prodid", "-//La Suite//Calendars//FR"))
+            single_cal.add("version", "2.0")
+
+            for tz in timezones:
+                single_cal.add_component(tz)
+            for component in components:
+                single_cal.add_component(component)
+
+            events[uid] = single_cal.to_ical().decode("utf-8")
+
+        return events
+
+    # SabreDAV limit for recurring event instances
+    MAX_RRULE_INSTANCES = 3500
+
+    @staticmethod
+    def _cap_infinite_rrule(component):
+        """Add COUNT to RRULEs with no COUNT or UNTIL.
+
+        SabreDAV rejects recurring events that generate more than 3500
+        instances (MaxInstancesExceededException). We add COUNT=3499
+        to stay safely under the limit.
+        """
+        rrule = component.get("rrule")
+        if not rrule:
+            return
+
+        has_count = "COUNT" in rrule
+        has_until = "UNTIL" in rrule
+        if has_count or has_until:
+            return
+
+        try:
+            rrule["COUNT"] = [SubscriptionSyncService.MAX_RRULE_INSTANCES - 1]
+            logger.info(
+                "Capped infinite RRULE for event %s with COUNT=%d",
+                component.get("uid", "?"),
+                SubscriptionSyncService.MAX_RRULE_INSTANCES - 1,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to cap RRULE for event %s",
+                component.get("uid", "?"),
+            )
+
+    # Properties that change on every export without meaningful data change
+    VOLATILE_PROPS = {"DTSTAMP", "LAST-MODIFIED", "SEQUENCE", "CREATED"}
+
+    @staticmethod
+    def _event_props(component) -> dict:
+        """Extract non-volatile properties from a VEVENT as a comparable dict."""
+        return {
+            k: str(v)
+            for k, v in component.items()
+            if k not in SubscriptionSyncService.VOLATILE_PROPS
+        }
+
+    @staticmethod
+    def _events_differ(existing_data: str, new_data: str) -> bool:
+        """Compare two VCALENDAR strings to detect meaningful changes.
+
+        Compares the VEVENT components property-by-property, ignoring
+        volatile properties (DTSTAMP, LAST-MODIFIED, SEQUENCE, CREATED)
+        that change on every export without real data change.
+        """
+        try:
+            existing_cal = icalendar.Calendar.from_ical(existing_data)
+            new_cal = icalendar.Calendar.from_ical(new_data)
+
+            existing_events = list(existing_cal.walk("VEVENT"))
+            new_events = list(new_cal.walk("VEVENT"))
+
+            if len(existing_events) != len(new_events):
+                return True
+
+            # Group by RECURRENCE-ID to handle reordered override instances
+            def _keyed(events):
+                return {
+                    str(ev.get("RECURRENCE-ID", "")): SubscriptionSyncService._event_props(ev)
+                    for ev in events
+                }
+
+            return _keyed(existing_events) != _keyed(new_events)
+        except Exception:  # noqa: BLE001
+            # If we can't parse, assume different to be safe
+            return True

--- a/src/backend/core/services/url_validation.py
+++ b/src/backend/core/services/url_validation.py
@@ -1,0 +1,229 @@
+"""URL validation for external calendar subscriptions.
+
+Validates subscription URLs against SSRF attacks and ensures they point
+to valid, reachable ICS resources.
+"""
+
+import ipaddress
+import logging
+import socket
+from urllib.parse import urljoin, urlparse
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+USER_AGENT = "La-Suite-Calendars/1.0"
+MAX_RESPONSE_SIZE = 10 * 1024 * 1024  # 10 MB
+CONNECT_TIMEOUT = 10  # seconds
+READ_TIMEOUT = 30  # seconds
+MAX_REDIRECTS = 3
+
+
+class URLValidationError(Exception):
+    """Raised when a subscription URL fails validation."""
+
+
+def _is_private_ip(ip_str: str) -> bool:
+    """Check if an IP address is private, loopback, or link-local."""
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return True  # fail-closed on unparseable addresses
+    # Unwrap IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1)
+    # before classification, since Python's IPv6Address.is_private
+    # returns False for these.
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
+        addr = addr.ipv4_mapped
+    return (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local
+        or addr.is_reserved
+        or addr.is_multicast
+    )
+
+
+def _resolve_and_check(hostname: str) -> str:
+    """Resolve hostname and verify it doesn't point to a private IP.
+
+    Returns the resolved IP address string.
+    Raises URLValidationError if the IP is private.
+    """
+    try:
+        results = socket.getaddrinfo(
+            hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM
+        )
+    except socket.gaierror as exc:
+        raise URLValidationError(f"Cannot resolve hostname: {hostname}") from exc
+
+    if not results:
+        raise URLValidationError(f"Cannot resolve hostname: {hostname}")
+
+    # Check ALL resolved IPs — reject if any is private
+    for _family, _type, _proto, _canonname, sockaddr in results:
+        ip_str = sockaddr[0]
+        if _is_private_ip(ip_str):
+            raise URLValidationError("URL resolves to a private network address")
+
+    return results[0][4][0]
+
+
+def normalize_url(url: str) -> str:
+    """Normalize a subscription URL (e.g. webcal:// to https://)."""
+    url = url.strip()
+    if url.lower().startswith("webcal://"):
+        url = "https://" + url[len("webcal://") :]
+    return url
+
+
+def validate_subscription_url(url: str) -> str:
+    """Validate and normalize a subscription URL.
+
+    Checks:
+    - URL is well-formed
+    - Scheme is HTTPS
+    - Hostname doesn't resolve to a private IP
+
+    Returns the normalized URL.
+    Raises URLValidationError on failure.
+    """
+    url = normalize_url(url)
+
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise URLValidationError("Only HTTPS URLs are allowed")
+
+    if not parsed.hostname:
+        raise URLValidationError("Invalid URL: no hostname")
+
+    _resolve_and_check(parsed.hostname)
+
+    return url
+
+
+def _safe_get(url, headers):
+    """Make a GET request with SSRF-safe redirect handling."""
+    try:
+        response = requests.get(
+            url,
+            headers=headers,
+            timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
+            stream=True,
+            allow_redirects=False,
+        )
+    except requests.exceptions.Timeout as exc:
+        raise URLValidationError("Request timed out") from exc
+    except requests.exceptions.RequestException as exc:
+        raise URLValidationError(f"Failed to fetch URL: {exc}") from exc
+
+    # Handle redirects manually to check each hop for SSRF
+    current_url = url
+    redirect_count = 0
+    # Strip conditional headers for redirect targets to avoid false 304s
+    redirect_headers = {
+        k: v for k, v in headers.items()
+        if k not in ("If-None-Match", "If-Modified-Since")
+    }
+    while response.status_code in (301, 302, 303, 307, 308):
+        redirect_count += 1
+        if redirect_count > MAX_REDIRECTS:
+            raise URLValidationError(f"Too many redirects (max {MAX_REDIRECTS})")
+
+        location = response.headers.get("Location", "")
+        if not location:
+            raise URLValidationError("Redirect without Location header")
+
+        # Resolve relative redirects against the current URL
+        location = urljoin(current_url, location)
+        redirect_parsed = urlparse(location)
+
+        if redirect_parsed.scheme != "https":
+            raise URLValidationError("Redirect to non-HTTPS URL")
+        if not redirect_parsed.hostname:
+            raise URLValidationError("Redirect to URL without hostname")
+        _resolve_and_check(redirect_parsed.hostname)
+
+        current_url = location
+        try:
+            response = requests.get(
+                location,
+                headers=redirect_headers,
+                timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
+                stream=True,
+                allow_redirects=False,
+            )
+        except requests.exceptions.Timeout as exc:
+            raise URLValidationError("Request timed out during redirect") from exc
+        except requests.exceptions.RequestException as exc:
+            raise URLValidationError(f"Failed during redirect: {exc}") from exc
+
+    return response
+
+
+def _read_response_body(response, url):
+    """Read response body with size limit and ICS validation."""
+    content_type = response.headers.get("Content-Type", "")
+    if (
+        "text/calendar" not in content_type
+        and "application/octet-stream" not in content_type
+    ):
+        logger.warning("Unexpected Content-Type %r for %s", content_type, url)
+
+    chunks = []
+    total_size = 0
+    for chunk in response.iter_content(chunk_size=8192):
+        total_size += len(chunk)
+        if total_size > MAX_RESPONSE_SIZE:
+            response.close()
+            raise URLValidationError(
+                f"Response too large (max {MAX_RESPONSE_SIZE // (1024 * 1024)} MB)"
+            )
+        chunks.append(chunk)
+
+    ics_data = b"".join(chunks)
+    if not ics_data or b"BEGIN:VCALENDAR" not in ics_data:
+        raise URLValidationError("URL does not return valid calendar data")
+
+    return ics_data
+
+
+def fetch_ics(url: str, etag: str = "", last_modified: str = "") -> tuple:
+    """Fetch an ICS resource with conditional request support.
+
+    Returns (status_code, ics_data_or_None, new_etag, new_last_modified).
+    Raises URLValidationError on network errors, invalid content, or SSRF.
+    """
+    url = normalize_url(url)
+    parsed = urlparse(url)
+
+    if parsed.scheme != "https":
+        raise URLValidationError("Only HTTPS URLs are allowed")
+
+    # Re-validate IP at fetch time (best-effort DNS rebinding mitigation).
+    # Note: there is still a TOCTOU window between this check and the
+    # actual TCP connection made by requests. A complete fix would require
+    # a custom requests adapter that pins to the pre-resolved IP.
+    # Network-level controls (e.g. firewall blocking egress to private
+    # ranges) provide a stronger second layer of defence.
+    if parsed.hostname:
+        _resolve_and_check(parsed.hostname)
+
+    headers = {"User-Agent": USER_AGENT}
+    if etag:
+        headers["If-None-Match"] = etag
+    if last_modified:
+        headers["If-Modified-Since"] = last_modified
+
+    response = _safe_get(url, headers)
+
+    if response.status_code == 304:
+        return 304, None, etag, last_modified
+
+    if response.status_code != 200:
+        raise URLValidationError(f"Server returned HTTP {response.status_code}")
+
+    ics_data = _read_response_body(response, url)
+    new_etag = response.headers.get("ETag", "")
+    new_last_modified = response.headers.get("Last-Modified", "")
+    return 200, ics_data, new_etag, new_last_modified

--- a/src/backend/core/services/url_validation.py
+++ b/src/backend/core/services/url_validation.py
@@ -7,7 +7,7 @@ to valid, reachable ICS resources.
 import ipaddress
 import logging
 import socket
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse, urlunparse
 
 import requests
 
@@ -22,6 +22,22 @@ MAX_REDIRECTS = 3
 
 class URLValidationError(Exception):
     """Raised when a subscription URL fails validation."""
+
+
+def _redact_url(url: str) -> str:
+    """Strip query string and fragment to avoid leaking signed tokens.
+
+    Subscription URLs can embed HMAC or bearer tokens in the query
+    string (e.g. Google Calendar private ICS URLs). Those tokens end up
+    in ``channel.settings['last_sync_error']`` and from there into the
+    API response / frontend, so we strip them from any string that
+    might be logged or raised.
+    """
+    try:
+        parsed = urlparse(url)
+        return urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
+    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        return "[unparseable url]"
 
 
 def _is_private_ip(ip_str: str) -> bool:
@@ -103,7 +119,12 @@ def validate_subscription_url(url: str) -> str:
 
 
 def _safe_get(url, headers):
-    """Make a GET request with SSRF-safe redirect handling."""
+    """Make a GET request with SSRF-safe redirect handling.
+
+    Responses are streamed; intermediate redirect responses are closed
+    as soon as the next request fires. Callers are responsible for
+    closing the final returned response.
+    """
     try:
         response = requests.get(
             url,
@@ -115,48 +136,59 @@ def _safe_get(url, headers):
     except requests.exceptions.Timeout as exc:
         raise URLValidationError("Request timed out") from exc
     except requests.exceptions.RequestException as exc:
-        raise URLValidationError(f"Failed to fetch URL: {exc}") from exc
+        raise URLValidationError(f"Failed to fetch URL: {_redact_url(url)}") from exc
 
     # Handle redirects manually to check each hop for SSRF
     current_url = url
     redirect_count = 0
     # Strip conditional headers for redirect targets to avoid false 304s
     redirect_headers = {
-        k: v for k, v in headers.items()
+        k: v
+        for k, v in headers.items()
         if k not in ("If-None-Match", "If-Modified-Since")
     }
-    while response.status_code in (301, 302, 303, 307, 308):
-        redirect_count += 1
-        if redirect_count > MAX_REDIRECTS:
-            raise URLValidationError(f"Too many redirects (max {MAX_REDIRECTS})")
+    try:
+        while response.status_code in (301, 302, 303, 307, 308):
+            redirect_count += 1
+            if redirect_count > MAX_REDIRECTS:
+                raise URLValidationError(f"Too many redirects (max {MAX_REDIRECTS})")
 
-        location = response.headers.get("Location", "")
-        if not location:
-            raise URLValidationError("Redirect without Location header")
+            location = response.headers.get("Location", "")
+            if not location:
+                raise URLValidationError("Redirect without Location header")
 
-        # Resolve relative redirects against the current URL
-        location = urljoin(current_url, location)
-        redirect_parsed = urlparse(location)
+            # Resolve relative redirects against the current URL
+            location = urljoin(current_url, location)
+            redirect_parsed = urlparse(location)
 
-        if redirect_parsed.scheme != "https":
-            raise URLValidationError("Redirect to non-HTTPS URL")
-        if not redirect_parsed.hostname:
-            raise URLValidationError("Redirect to URL without hostname")
-        _resolve_and_check(redirect_parsed.hostname)
+            if redirect_parsed.scheme != "https":
+                raise URLValidationError("Redirect to non-HTTPS URL")
+            if not redirect_parsed.hostname:
+                raise URLValidationError("Redirect to URL without hostname")
+            _resolve_and_check(redirect_parsed.hostname)
 
-        current_url = location
-        try:
-            response = requests.get(
-                location,
-                headers=redirect_headers,
-                timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
-                stream=True,
-                allow_redirects=False,
-            )
-        except requests.exceptions.Timeout as exc:
-            raise URLValidationError("Request timed out during redirect") from exc
-        except requests.exceptions.RequestException as exc:
-            raise URLValidationError(f"Failed during redirect: {exc}") from exc
+            current_url = location
+            # Release the previous streamed response before issuing the
+            # next hop so we don't leak connections on long redirect
+            # chains.
+            response.close()
+            try:
+                response = requests.get(
+                    location,
+                    headers=redirect_headers,
+                    timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
+                    stream=True,
+                    allow_redirects=False,
+                )
+            except requests.exceptions.Timeout as exc:
+                raise URLValidationError("Request timed out during redirect") from exc
+            except requests.exceptions.RequestException as exc:
+                raise URLValidationError(
+                    f"Failed during redirect: {_redact_url(location)}"
+                ) from exc
+    except BaseException:
+        response.close()
+        raise
 
     return response
 
@@ -168,18 +200,24 @@ def _read_response_body(response, url):
         "text/calendar" not in content_type
         and "application/octet-stream" not in content_type
     ):
-        logger.warning("Unexpected Content-Type %r for %s", content_type, url)
+        logger.warning(
+            "Unexpected Content-Type %r for %s", content_type, _redact_url(url)
+        )
 
     chunks = []
     total_size = 0
-    for chunk in response.iter_content(chunk_size=8192):
-        total_size += len(chunk)
-        if total_size > MAX_RESPONSE_SIZE:
-            response.close()
-            raise URLValidationError(
-                f"Response too large (max {MAX_RESPONSE_SIZE // (1024 * 1024)} MB)"
-            )
-        chunks.append(chunk)
+    try:
+        for chunk in response.iter_content(chunk_size=8192):
+            total_size += len(chunk)
+            if total_size > MAX_RESPONSE_SIZE:
+                raise URLValidationError(
+                    f"Response too large (max {MAX_RESPONSE_SIZE // (1024 * 1024)} MB)"
+                )
+            chunks.append(chunk)
+    except requests.exceptions.RequestException as exc:
+        raise URLValidationError(
+            f"Failed to read response body: {_redact_url(url)}"
+        ) from exc
 
     ics_data = b"".join(chunks)
     if not ics_data or b"BEGIN:VCALENDAR" not in ics_data:
@@ -216,14 +254,16 @@ def fetch_ics(url: str, etag: str = "", last_modified: str = "") -> tuple:
         headers["If-Modified-Since"] = last_modified
 
     response = _safe_get(url, headers)
+    try:
+        if response.status_code == 304:
+            return 304, None, etag, last_modified
 
-    if response.status_code == 304:
-        return 304, None, etag, last_modified
+        if response.status_code != 200:
+            raise URLValidationError(f"Server returned HTTP {response.status_code}")
 
-    if response.status_code != 200:
-        raise URLValidationError(f"Server returned HTTP {response.status_code}")
-
-    ics_data = _read_response_body(response, url)
-    new_etag = response.headers.get("ETag", "")
-    new_last_modified = response.headers.get("Last-Modified", "")
-    return 200, ics_data, new_etag, new_last_modified
+        ics_data = _read_response_body(response, url)
+        new_etag = response.headers.get("ETag", "")
+        new_last_modified = response.headers.get("Last-Modified", "")
+        return 200, ics_data, new_etag, new_last_modified
+    finally:
+        response.close()

--- a/src/backend/core/services/url_validation.py
+++ b/src/backend/core/services/url_validation.py
@@ -2,11 +2,27 @@
 
 Validates subscription URLs against SSRF attacks and ensures they point
 to valid, reachable ICS resources.
+
+DNS rebinding defence
+---------------------
+``_resolve_and_check`` validates that the DNS answer is not a private
+address, but that answer would be looked up again when ``requests`` opens
+the socket, leaving a short TOCTOU window an attacker can exploit with a
+low-TTL rebinding record. To close it, the fetch helpers run the actual
+``requests.get`` call inside ``_pin_hostname``: a thread-local patch of
+``socket.getaddrinfo`` that re-routes the exact hostname → IP pair we
+just validated. TLS still uses the original hostname for SNI and cert
+verification (urllib3 passes it independently of DNS), so there is no
+cert mismatch. The patch is transparent for every hostname not pinned
+by the current thread. Operators are still encouraged to block egress
+to private CIDRs at the network layer as a second line of defence.
 """
 
+import contextlib
 import ipaddress
 import logging
 import socket
+import threading
 from urllib.parse import urljoin, urlparse, urlunparse
 
 import requests
@@ -65,6 +81,11 @@ def _resolve_and_check(hostname: str) -> str:
 
     Returns the resolved IP address string.
     Raises URLValidationError if the IP is private.
+
+    Safe to call while the DNS pinning patch is installed: every caller
+    in this module invokes ``_resolve_and_check`` *before* entering a
+    ``_pin_hostname`` context for the same hostname, and the patch falls
+    through whenever no pin is active for the current thread.
     """
     try:
         results = socket.getaddrinfo(
@@ -83,6 +104,61 @@ def _resolve_and_check(hostname: str) -> str:
             raise URLValidationError("URL resolves to a private network address")
 
     return results[0][4][0]
+
+
+# --- DNS pinning (rebinding mitigation) -------------------------------------
+
+_ORIG_GETADDRINFO = socket.getaddrinfo
+_DNS_PIN_LOCAL = threading.local()
+_DNS_PATCH_LOCK = threading.Lock()
+_DNS_PATCHED = False
+
+
+def _pinned_getaddrinfo(host, *args, **kwargs):
+    """Resolve a pinned hostname to its validated IP literal.
+
+    Falls through to the real resolver for every hostname not pinned by
+    the current thread, so this patch is invisible to the rest of the
+    process.
+    """
+    pin_map = getattr(_DNS_PIN_LOCAL, "map", None)
+    if pin_map and host in pin_map:
+        return _ORIG_GETADDRINFO(pin_map[host], *args, **kwargs)
+    return _ORIG_GETADDRINFO(host, *args, **kwargs)
+
+
+def _install_dns_patch() -> None:
+    """Install the ``socket.getaddrinfo`` patch once, lazily."""
+    global _DNS_PATCHED  # noqa: PLW0603  # pylint: disable=global-statement
+    with _DNS_PATCH_LOCK:
+        if not _DNS_PATCHED:
+            socket.getaddrinfo = _pinned_getaddrinfo
+            _DNS_PATCHED = True
+
+
+@contextlib.contextmanager
+def _pin_hostname(hostname: str, safe_ip: str):
+    """Thread-local DNS pin of ``hostname`` to ``safe_ip``.
+
+    Closes the TOCTOU window between ``_resolve_and_check`` and the TCP
+    connect performed by ``requests``: while the context is active, any
+    lookup of ``hostname`` in this thread resolves to the pre-validated
+    IP. Nested/re-entrant pins restore the previous value on exit.
+    """
+    _install_dns_patch()
+    pin_map = getattr(_DNS_PIN_LOCAL, "map", None)
+    if pin_map is None:
+        pin_map = {}
+        _DNS_PIN_LOCAL.map = pin_map
+    previous = pin_map.get(hostname)
+    pin_map[hostname] = safe_ip
+    try:
+        yield
+    finally:
+        if previous is None:
+            pin_map.pop(hostname, None)
+        else:
+            pin_map[hostname] = previous
 
 
 def normalize_url(url: str) -> str:
@@ -118,25 +194,43 @@ def validate_subscription_url(url: str) -> str:
     return url
 
 
+def _pinned_get(url: str, headers: dict, *, timeout_msg: str):
+    """Issue a streaming GET with the hostname pinned to a validated IP.
+
+    Validates the URL's hostname, pins DNS for the lifetime of the
+    ``requests.get`` call, and returns the streamed response. The TCP
+    socket is already open by the time the pin is released, so later
+    body reads on the returned response are safe.
+    """
+    parsed = urlparse(url)
+    if not parsed.hostname:
+        raise URLValidationError("URL without hostname")
+    safe_ip = _resolve_and_check(parsed.hostname)
+    try:
+        with _pin_hostname(parsed.hostname, safe_ip):
+            return requests.get(
+                url,
+                headers=headers,
+                timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
+                stream=True,
+                allow_redirects=False,
+            )
+    except requests.exceptions.Timeout as exc:
+        raise URLValidationError(timeout_msg) from exc
+    except requests.exceptions.RequestException as exc:
+        raise URLValidationError(f"Failed to fetch URL: {_redact_url(url)}") from exc
+
+
 def _safe_get(url, headers):
     """Make a GET request with SSRF-safe redirect handling.
 
-    Responses are streamed; intermediate redirect responses are closed
-    as soon as the next request fires. Callers are responsible for
-    closing the final returned response.
+    Each hop re-validates the hostname and pins DNS before the TCP
+    connect, closing the rebinding TOCTOU window for both the initial
+    URL and every redirect target. Intermediate redirect responses are
+    closed as soon as the next request fires; callers are responsible
+    for closing the final returned response.
     """
-    try:
-        response = requests.get(
-            url,
-            headers=headers,
-            timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
-            stream=True,
-            allow_redirects=False,
-        )
-    except requests.exceptions.Timeout as exc:
-        raise URLValidationError("Request timed out") from exc
-    except requests.exceptions.RequestException as exc:
-        raise URLValidationError(f"Failed to fetch URL: {_redact_url(url)}") from exc
+    response = _pinned_get(url, headers, timeout_msg="Request timed out")
 
     # Handle redirects manually to check each hop for SSRF
     current_url = url
@@ -165,27 +259,17 @@ def _safe_get(url, headers):
                 raise URLValidationError("Redirect to non-HTTPS URL")
             if not redirect_parsed.hostname:
                 raise URLValidationError("Redirect to URL without hostname")
-            _resolve_and_check(redirect_parsed.hostname)
 
             current_url = location
             # Release the previous streamed response before issuing the
             # next hop so we don't leak connections on long redirect
             # chains.
             response.close()
-            try:
-                response = requests.get(
-                    location,
-                    headers=redirect_headers,
-                    timeout=(CONNECT_TIMEOUT, READ_TIMEOUT),
-                    stream=True,
-                    allow_redirects=False,
-                )
-            except requests.exceptions.Timeout as exc:
-                raise URLValidationError("Request timed out during redirect") from exc
-            except requests.exceptions.RequestException as exc:
-                raise URLValidationError(
-                    f"Failed during redirect: {_redact_url(location)}"
-                ) from exc
+            response = _pinned_get(
+                location,
+                redirect_headers,
+                timeout_msg="Request timed out during redirect",
+            )
     except BaseException:
         response.close()
         raise
@@ -238,14 +322,10 @@ def fetch_ics(url: str, etag: str = "", last_modified: str = "") -> tuple:
     if parsed.scheme != "https":
         raise URLValidationError("Only HTTPS URLs are allowed")
 
-    # Re-validate IP at fetch time (best-effort DNS rebinding mitigation).
-    # Note: there is still a TOCTOU window between this check and the
-    # actual TCP connection made by requests. A complete fix would require
-    # a custom requests adapter that pins to the pre-resolved IP.
-    # Network-level controls (e.g. firewall blocking egress to private
-    # ranges) provide a stronger second layer of defence.
-    if parsed.hostname:
-        _resolve_and_check(parsed.hostname)
+    # DNS rebinding is handled inside ``_safe_get``: every hop validates
+    # and pins the hostname so the TCP connect lands on the pre-checked
+    # IP. Operators are still encouraged to block egress to private
+    # CIDRs at the network layer as a second line of defence.
 
     headers = {"User-Agent": USER_AGENT}
     if etag:

--- a/src/backend/core/tasks.py
+++ b/src/backend/core/tasks.py
@@ -13,6 +13,59 @@ from core.task_utils import register_task, set_task_progress
 logger = logging.getLogger(__name__)
 
 
+@register_task(queue="sync")
+def sync_one_subscription(channel_id):
+    """Sync a single external calendar subscription."""
+    from core.services.subscription_sync_service import (  # noqa: PLC0415
+        SubscriptionSyncService,
+    )
+
+    service = SubscriptionSyncService()
+    return service.sync_channel(channel_id)
+
+
+@register_task(queue="sync")
+def sync_all_subscriptions():
+    """Fan out sync tasks for all active subscriptions due for sync."""
+    from django.utils import timezone as tz  # noqa: PLC0415
+
+    from core.models import Channel  # noqa: PLC0415
+
+    now = tz.now()
+    channels = Channel.objects.filter(
+        type="ical-subscription",
+        is_active=True,
+    ).iterator(chunk_size=500)
+
+    dispatched = 0
+    for channel in channels:
+        sync_interval = max(channel.settings.get("sync_interval", 300), 1)
+        last_sync_at = channel.settings.get("last_sync_at")
+
+        # Check if channel is due for sync
+        if last_sync_at:
+            from django.utils.dateparse import (  # noqa: PLC0415
+                parse_datetime,
+            )
+
+            last_sync = parse_datetime(last_sync_at)
+            if last_sync and (now - last_sync).total_seconds() < sync_interval:
+                continue
+
+        # Stagger delay based on channel ID (deterministic across restarts)
+        import uuid  # noqa: PLC0415
+
+        delay_ms = (int(uuid.UUID(str(channel.pk))) % sync_interval) * 1000
+        sync_one_subscription.send_with_options(
+            args=(str(channel.pk),),
+            delay=delay_ms,
+        )
+        dispatched += 1
+
+    logger.info("Dispatched %d subscription sync tasks", dispatched)
+    return dispatched
+
+
 @register_task(queue="import")
 def import_events_task(user_id, caldav_path, ics_data_hex):
     """Import events from ICS data in the background.

--- a/src/backend/core/tasks.py
+++ b/src/backend/core/tasks.py
@@ -39,7 +39,18 @@ def sync_all_subscriptions():
 
     dispatched = 0
     for channel in channels:
-        sync_interval = max(channel.settings.get("sync_interval", 300), 1)
+        raw_sync_interval = channel.settings.get(
+            "sync_interval", settings.SUBSCRIPTION_SYNC_INTERVAL
+        )
+        try:
+            sync_interval = max(int(raw_sync_interval), 1)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid sync_interval for channel %s: %r",
+                channel.pk,
+                raw_sync_interval,
+            )
+            sync_interval = settings.SUBSCRIPTION_SYNC_INTERVAL
         last_sync_at = channel.settings.get("last_sync_at")
 
         # Check if channel is due for sync

--- a/src/backend/core/tests/test_calendar_subscription_api.py
+++ b/src/backend/core/tests/test_calendar_subscription_api.py
@@ -417,19 +417,17 @@ class TestSubscriptionChannelLimit:
 
     @patch("core.api.viewsets_channels.CalDAVClient")
     @patch("core.api.viewsets_channels.fetch_ics")
-    def test_create_subscription_limit_reached(self, mock_fetch, mock_caldav):
+    def test_create_subscription_limit_reached(self, mock_fetch, mock_caldav):  # pylint: disable=unused-argument
         """Cannot create a 21st subscription when limit is 20."""
         user = factories.UserFactory()
         client = APIClient()
         client.force_login(user)
 
         # Create 20 subscription channels
-        for i in range(20):
+        for _ in range(20):
             factories.ICalSubscriptionChannelFactory(user=user)
 
-        assert Channel.objects.filter(
-            user=user, type="ical-subscription"
-        ).count() == 20
+        assert Channel.objects.filter(user=user, type="ical-subscription").count() == 20
 
         response = client.post(
             CHANNELS_URL,
@@ -476,9 +474,7 @@ class TestSubscriptionChannelLimit:
         )
 
         assert response.status_code == HTTP_201_CREATED
-        assert Channel.objects.filter(
-            user=user, type="ical-subscription"
-        ).count() == 20
+        assert Channel.objects.filter(user=user, type="ical-subscription").count() == 20
 
 
 @pytest.mark.django_db
@@ -492,18 +488,12 @@ class TestSubscriptionUrlChangePurge:
         client.force_login(channel.user)
 
         with (
-            patch(
-                "core.api.viewsets_channels.fetch_ics"
-            ) as mock_fetch,
+            patch("core.api.viewsets_channels.fetch_ics") as mock_fetch,
             patch(
                 "core.services.subscription_sync_service.SubscriptionSyncService"
             ) as mock_svc_cls,
-            patch(
-                "core.api.viewsets_channels.CalDAVClient"
-            ),
-            patch(
-                "core.tasks.sync_one_subscription"
-            ),
+            patch("core.api.viewsets_channels.CalDAVClient"),
+            patch("core.tasks.sync_one_subscription"),
         ):
             mock_fetch.return_value = (200, VALID_ICS, '"new"', "Tue, 02 Jan")
             mock_svc = MagicMock()
@@ -516,9 +506,7 @@ class TestSubscriptionUrlChangePurge:
             )
 
         assert response.status_code == HTTP_200_OK
-        mock_svc.purge_events.assert_called_once_with(
-            channel.user, channel.caldav_path
-        )
+        mock_svc.purge_events.assert_called_once_with(channel.user, channel.caldav_path)
 
     def test_update_name_only_no_purge(self):
         """Changing only the name should not trigger purge."""
@@ -527,9 +515,7 @@ class TestSubscriptionUrlChangePurge:
         client.force_login(channel.user)
 
         with (
-            patch(
-                "core.api.viewsets_channels.CalDAVClient"
-            ),
+            patch("core.api.viewsets_channels.CalDAVClient"),
             patch(
                 "core.services.subscription_sync_service.SubscriptionSyncService"
             ) as mock_svc_cls,

--- a/src/backend/core/tests/test_calendar_subscription_api.py
+++ b/src/backend/core/tests/test_calendar_subscription_api.py
@@ -1,10 +1,13 @@
 """Tests for iCal feed channel creation via the channels API."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from rest_framework.status import (
     HTTP_200_OK,
     HTTP_201_CREATED,
     HTTP_204_NO_CONTENT,
+    HTTP_400_BAD_REQUEST,
     HTTP_401_UNAUTHORIZED,
     HTTP_403_FORBIDDEN,
 )
@@ -398,3 +401,147 @@ class TestPathInjectionProtection:
         )
 
         assert response.status_code == HTTP_201_CREATED
+
+
+VALID_ICS = (
+    b"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//Test//EN\r\n"
+    b"BEGIN:VEVENT\r\nUID:test-1\r\nSUMMARY:Test\r\n"
+    b"DTSTART:20260101T100000Z\r\nDTEND:20260101T110000Z\r\n"
+    b"END:VEVENT\r\nEND:VCALENDAR"
+)
+
+
+@pytest.mark.django_db
+class TestSubscriptionChannelLimit:
+    """Tests for per-user subscription limit enforcement (#3)."""
+
+    @patch("core.api.viewsets_channels.CalDAVClient")
+    @patch("core.api.viewsets_channels.fetch_ics")
+    def test_create_subscription_limit_reached(self, mock_fetch, mock_caldav):
+        """Cannot create a 21st subscription when limit is 20."""
+        user = factories.UserFactory()
+        client = APIClient()
+        client.force_login(user)
+
+        # Create 20 subscription channels
+        for i in range(20):
+            factories.ICalSubscriptionChannelFactory(user=user)
+
+        assert Channel.objects.filter(
+            user=user, type="ical-subscription"
+        ).count() == 20
+
+        response = client.post(
+            CHANNELS_URL,
+            {
+                "type": "ical-subscription",
+                "name": "One too many",
+                "source_url": "https://example.com/overflow.ics",
+            },
+            format="json",
+        )
+
+        assert response.status_code == HTTP_400_BAD_REQUEST
+        assert "Maximum" in response.data["detail"]
+        # fetch_ics should not even be called
+        mock_fetch.assert_not_called()
+
+    @patch("core.api.viewsets_channels.CalDAVClient")
+    @patch("core.api.viewsets_channels.fetch_ics")
+    def test_create_subscription_under_limit(self, mock_fetch, mock_caldav):
+        """Can create the 20th subscription (limit not exceeded)."""
+        user = factories.UserFactory()
+        client = APIClient()
+        client.force_login(user)
+
+        # Create 19 subscription channels
+        for _ in range(19):
+            factories.ICalSubscriptionChannelFactory(user=user)
+
+        mock_fetch.return_value = (200, VALID_ICS, '"etag"', "Mon, 01 Jan 2026")
+        mock_caldav_instance = MagicMock()
+        mock_caldav_instance.create_calendar.return_value = (
+            f"/calendars/users/{user.email}/new-uuid/"
+        )
+        mock_caldav.return_value = mock_caldav_instance
+
+        response = client.post(
+            CHANNELS_URL,
+            {
+                "type": "ical-subscription",
+                "name": "Last allowed",
+                "source_url": "https://example.com/last.ics",
+            },
+            format="json",
+        )
+
+        assert response.status_code == HTTP_201_CREATED
+        assert Channel.objects.filter(
+            user=user, type="ical-subscription"
+        ).count() == 20
+
+
+@pytest.mark.django_db
+class TestSubscriptionUrlChangePurge:
+    """Tests for event purge when source URL changes (#5)."""
+
+    def test_update_source_url_purges_events(self):
+        """Changing source_url triggers purge_events before sync."""
+        channel = factories.ICalSubscriptionChannelFactory()
+        client = APIClient()
+        client.force_login(channel.user)
+
+        with (
+            patch(
+                "core.api.viewsets_channels.fetch_ics"
+            ) as mock_fetch,
+            patch(
+                "core.services.subscription_sync_service.SubscriptionSyncService"
+            ) as mock_svc_cls,
+            patch(
+                "core.api.viewsets_channels.CalDAVClient"
+            ),
+            patch(
+                "core.tasks.sync_one_subscription"
+            ),
+        ):
+            mock_fetch.return_value = (200, VALID_ICS, '"new"', "Tue, 02 Jan")
+            mock_svc = MagicMock()
+            mock_svc_cls.return_value = mock_svc
+
+            response = client.patch(
+                f"{CHANNELS_URL}{channel.pk}/",
+                {"source_url": "https://new-source.com/cal.ics"},
+                format="json",
+            )
+
+        assert response.status_code == HTTP_200_OK
+        mock_svc.purge_events.assert_called_once_with(
+            channel.user, channel.caldav_path
+        )
+
+    def test_update_name_only_no_purge(self):
+        """Changing only the name should not trigger purge."""
+        channel = factories.ICalSubscriptionChannelFactory()
+        client = APIClient()
+        client.force_login(channel.user)
+
+        with (
+            patch(
+                "core.api.viewsets_channels.CalDAVClient"
+            ),
+            patch(
+                "core.services.subscription_sync_service.SubscriptionSyncService"
+            ) as mock_svc_cls,
+        ):
+            mock_svc = MagicMock()
+            mock_svc_cls.return_value = mock_svc
+
+            response = client.patch(
+                f"{CHANNELS_URL}{channel.pk}/",
+                {"name": "Renamed"},
+                format="json",
+            )
+
+        assert response.status_code == HTTP_200_OK
+        mock_svc.purge_events.assert_not_called()

--- a/src/backend/core/tests/test_subscription_proxy.py
+++ b/src/backend/core/tests/test_subscription_proxy.py
@@ -1,5 +1,8 @@
 """Tests for CalDAV proxy read-only enforcement on subscription calendars."""
 
+# pylint: disable=missing-class-docstring,missing-function-docstring
+# pylint: disable=protected-access,redefined-outer-name,unused-argument
+
 import pytest
 
 from core.api.viewsets_caldav import CalDAVProxyView

--- a/src/backend/core/tests/test_subscription_proxy.py
+++ b/src/backend/core/tests/test_subscription_proxy.py
@@ -1,0 +1,121 @@
+"""Tests for CalDAV proxy read-only enforcement on subscription calendars."""
+
+import pytest
+
+from core.api.viewsets_caldav import CalDAVProxyView
+from core.factories import UserFactory
+from core.models import Channel
+
+
+@pytest.fixture()
+def user():
+    return UserFactory(email="test@example.com")
+
+
+@pytest.fixture()
+def subscription_channel(user):
+    return Channel.objects.create(
+        name="External Calendar",
+        type="ical-subscription",
+        user=user,
+        is_active=True,
+        caldav_path="/calendars/users/test@example.com/sub-uuid/",
+        settings={
+            "source_url": "https://example.com/cal.ics",
+            "sync_interval": 300,
+            "last_sync_status": "ok",
+            "error_count": 0,
+        },
+    )
+
+
+@pytest.mark.django_db
+class TestSubscriptionReadOnly:
+    def test_blocks_put_on_subscription_calendar(self, user, subscription_channel):
+        """PUT to a subscription calendar event should return 403."""
+        result = CalDAVProxyView._check_subscription_readonly(
+            user,
+            "calendars/users/test@example.com/sub-uuid/event-1.ics",
+            "PUT",
+        )
+        assert result is not None
+        assert result.status_code == 403
+
+    def test_blocks_delete_on_subscription_calendar(self, user, subscription_channel):
+        """DELETE on a subscription calendar event should return 403."""
+        result = CalDAVProxyView._check_subscription_readonly(
+            user,
+            "calendars/users/test@example.com/sub-uuid/event-1.ics",
+            "DELETE",
+        )
+        assert result is not None
+        assert result.status_code == 403
+
+    def test_allows_regular_calendar_put(self, user, subscription_channel):
+        """PUT to a regular calendar should not be blocked."""
+        result = CalDAVProxyView._check_subscription_readonly(
+            user,
+            "calendars/users/test@example.com/regular-uuid/event-1.ics",
+            "PUT",
+        )
+        assert result is None
+
+    def test_allows_when_no_subscriptions(self, user):
+        """When user has no subscription channels, writes should pass."""
+        result = CalDAVProxyView._check_subscription_readonly(
+            user,
+            "calendars/users/test@example.com/any-uuid/event-1.ics",
+            "PUT",
+        )
+        assert result is None
+
+    def test_inactive_subscription_still_blocks_writes(self, user):
+        """Inactive (stopped) subscription calendars must remain read-only."""
+        Channel.objects.create(
+            name="Inactive Sub",
+            type="ical-subscription",
+            user=user,
+            is_active=False,
+            caldav_path="/calendars/users/test@example.com/inactive-uuid/",
+            settings={
+                "source_url": "https://example.com/cal.ics",
+                "error_count": 3,
+            },
+        )
+        result = CalDAVProxyView._check_subscription_readonly(
+            user,
+            "calendars/users/test@example.com/inactive-uuid/event-1.ics",
+            "PUT",
+        )
+        assert result is not None
+        assert result.status_code == 403
+
+    def test_move_blocked_on_subscription(self, user, subscription_channel):
+        """MOVE on a subscription calendar should return 403."""
+        result = CalDAVProxyView._check_subscription_readonly(
+            user,
+            "calendars/users/test@example.com/sub-uuid/event-1.ics",
+            "MOVE",
+        )
+        assert result is not None
+        assert result.status_code == 403
+
+    def test_proppatch_blocked_on_subscription(self, user, subscription_channel):
+        """PROPPATCH on a subscription calendar event should return 403."""
+        result = CalDAVProxyView._check_subscription_readonly(
+            user,
+            "calendars/users/test@example.com/sub-uuid/event-1.ics",
+            "PROPPATCH",
+        )
+        assert result is not None
+        assert result.status_code == 403
+
+    def test_post_blocked_on_subscription(self, user, subscription_channel):
+        """POST on a subscription calendar should return 403."""
+        result = CalDAVProxyView._check_subscription_readonly(
+            user,
+            "calendars/users/test@example.com/sub-uuid/event-1.ics",
+            "POST",
+        )
+        assert result is not None
+        assert result.status_code == 403

--- a/src/backend/core/tests/test_subscription_sync.py
+++ b/src/backend/core/tests/test_subscription_sync.py
@@ -1,0 +1,341 @@
+"""Tests for subscription sync service."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.factories import UserFactory
+from core.models import Channel
+from core.services.subscription_sync_service import (
+    SubscriptionSyncService,
+    SyncResult,
+)
+from core.services.url_validation import URLValidationError
+
+VALID_ICS = (
+    b"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//Test//EN\r\n"
+    b"BEGIN:VEVENT\r\nUID:event-1@test\r\nDTSTART:20260101T100000Z\r\n"
+    b"DTEND:20260101T110000Z\r\nSUMMARY:Test Event\r\n"
+    b"END:VEVENT\r\nEND:VCALENDAR"
+)
+
+VALID_ICS_TWO_EVENTS = (
+    b"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//Test//EN\r\n"
+    b"BEGIN:VEVENT\r\nUID:event-1@test\r\nDTSTART:20260101T100000Z\r\n"
+    b"DTEND:20260101T110000Z\r\nSUMMARY:Test Event\r\n"
+    b"END:VEVENT\r\n"
+    b"BEGIN:VEVENT\r\nUID:event-2@test\r\nDTSTART:20260102T100000Z\r\n"
+    b"DTEND:20260102T110000Z\r\nSUMMARY:Test Event 2\r\n"
+    b"END:VEVENT\r\nEND:VCALENDAR"
+)
+
+
+class TestParseIcsEvents:
+    def test_parses_single_event(self):
+        service = SubscriptionSyncService()
+        events = service._parse_ics_events(VALID_ICS)
+        assert "event-1@test" in events
+        assert "BEGIN:VCALENDAR" in events["event-1@test"]
+        assert "BEGIN:VEVENT" in events["event-1@test"]
+
+    def test_parses_multiple_events(self):
+        service = SubscriptionSyncService()
+        events = service._parse_ics_events(VALID_ICS_TWO_EVENTS)
+        assert len(events) == 2
+        assert "event-1@test" in events
+        assert "event-2@test" in events
+
+
+class TestEventsDiffer:
+    def test_identical_events(self):
+        service = SubscriptionSyncService()
+        cal = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\n"
+            "BEGIN:VEVENT\r\nUID:test@test\r\nSUMMARY:Test\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR"
+        )
+        assert not service._events_differ(cal, cal)
+
+    def test_different_summary(self):
+        service = SubscriptionSyncService()
+        old = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\n"
+            "BEGIN:VEVENT\r\nUID:test@test\r\nSUMMARY:Old\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR"
+        )
+        new = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\n"
+            "BEGIN:VEVENT\r\nUID:test@test\r\nSUMMARY:New\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR"
+        )
+        assert service._events_differ(old, new)
+
+
+@pytest.mark.django_db
+class TestSyncChannel:
+    @patch("core.services.subscription_sync_service.fetch_ics")
+    @patch("core.services.subscription_sync_service.cache")
+    def test_304_skips_sync(self, mock_cache, mock_fetch):
+        """304 Not Modified should update last_sync_at without touching events."""
+        mock_cache.add.return_value = True  # Lock acquired
+        mock_fetch.return_value = (304, None, '"old-etag"', "old-date")
+
+        user = UserFactory()
+        channel = Channel.objects.create(
+            name="Test Sub",
+            type="ical-subscription",
+            user=user,
+            caldav_path="/calendars/users/test@test.com/uuid/",
+            settings={
+                "source_url": "https://example.com/cal.ics",
+                "sync_interval": 300,
+                "last_sync_status": "ok",
+                "error_count": 0,
+                "etag": '"old-etag"',
+                "last_modified": "old-date",
+            },
+        )
+
+        service = SubscriptionSyncService()
+        result = service.sync_channel(str(channel.pk))
+
+        assert result is True
+        channel.refresh_from_db()
+        assert channel.settings["last_sync_status"] == "ok"
+        assert channel.settings["last_sync_at"] is not None
+
+    @patch("core.services.subscription_sync_service.fetch_ics")
+    @patch("core.services.subscription_sync_service.cache")
+    def test_error_increments_count(self, mock_cache, mock_fetch):
+        """Fetch error should increment error_count."""
+        mock_cache.add.return_value = True
+        mock_fetch.side_effect = URLValidationError("timeout")
+
+        user = UserFactory()
+        channel = Channel.objects.create(
+            name="Test Sub",
+            type="ical-subscription",
+            user=user,
+            caldav_path="/calendars/users/test@test.com/uuid/",
+            settings={
+                "source_url": "https://example.com/cal.ics",
+                "sync_interval": 300,
+                "last_sync_status": "ok",
+                "error_count": 0,
+                "etag": "",
+                "last_modified": "",
+            },
+        )
+
+        service = SubscriptionSyncService()
+        result = service.sync_channel(str(channel.pk))
+
+        assert result is False
+        channel.refresh_from_db()
+        assert channel.settings["error_count"] == 1
+        assert channel.settings["last_sync_status"] == "error"
+        assert "timeout" in channel.settings["last_sync_error"]
+        assert channel.is_active is True  # not stopped yet
+
+    @patch("core.services.subscription_sync_service.fetch_ics")
+    @patch("core.services.subscription_sync_service.cache")
+    def test_three_strikes_auto_stop(self, mock_cache, mock_fetch):
+        """After 3 consecutive errors, channel should be deactivated."""
+        mock_cache.add.return_value = True
+        mock_fetch.side_effect = URLValidationError("server error")
+
+        user = UserFactory()
+        channel = Channel.objects.create(
+            name="Test Sub",
+            type="ical-subscription",
+            user=user,
+            caldav_path="/calendars/users/test@test.com/uuid/",
+            settings={
+                "source_url": "https://example.com/cal.ics",
+                "sync_interval": 300,
+                "last_sync_status": "error",
+                "error_count": 2,  # Already 2 errors
+                "etag": "",
+                "last_modified": "",
+            },
+        )
+
+        service = SubscriptionSyncService()
+        result = service.sync_channel(str(channel.pk))
+
+        assert result is False
+        channel.refresh_from_db()
+        assert channel.settings["error_count"] == 3
+        assert channel.is_active is False  # auto-stopped
+
+    @patch("core.services.subscription_sync_service.cache")
+    def test_lock_prevents_overlap(self, mock_cache):
+        """If lock is already held, sync should skip."""
+        mock_cache.add.return_value = False  # Lock NOT acquired
+
+        user = UserFactory()
+        channel = Channel.objects.create(
+            name="Test Sub",
+            type="ical-subscription",
+            user=user,
+            caldav_path="/calendars/users/test@test.com/uuid/",
+            settings={
+                "source_url": "https://example.com/cal.ics",
+                "sync_interval": 300,
+                "last_sync_status": "ok",
+                "error_count": 0,
+                "etag": "",
+                "last_modified": "",
+            },
+        )
+
+        service = SubscriptionSyncService()
+        result = service.sync_channel(str(channel.pk))
+
+        assert result is True  # Skipped, not an error
+
+    @patch("core.services.subscription_sync_service.cache")
+    def test_inactive_channel_skipped(self, mock_cache):
+        """Inactive channel should not be synced."""
+        mock_cache.add.return_value = True
+
+        user = UserFactory()
+        channel = Channel.objects.create(
+            name="Test Sub",
+            type="ical-subscription",
+            user=user,
+            is_active=False,
+            caldav_path="/calendars/users/test@test.com/uuid/",
+            settings={
+                "source_url": "https://example.com/cal.ics",
+                "sync_interval": 300,
+                "last_sync_status": "error",
+                "error_count": 3,
+                "etag": "",
+                "last_modified": "",
+            },
+        )
+
+        service = SubscriptionSyncService()
+        result = service.sync_channel(str(channel.pk))
+
+        assert result is False
+
+    @patch("core.services.subscription_sync_service.fetch_ics")
+    @patch("core.services.subscription_sync_service.cache")
+    def test_sync_survives_channel_deletion(self, mock_cache, mock_fetch):
+        """If channel is deleted during sync, save should not crash."""
+        mock_cache.add.return_value = True
+        mock_fetch.return_value = (304, None, '"etag"', "date")
+
+        user = UserFactory()
+        channel = Channel.objects.create(
+            name="Test Sub",
+            type="ical-subscription",
+            user=user,
+            caldav_path="/calendars/users/test@test.com/uuid/",
+            settings={
+                "source_url": "https://example.com/cal.ics",
+                "sync_interval": 300,
+                "last_sync_status": "ok",
+                "error_count": 0,
+                "etag": '"etag"',
+                "last_modified": "date",
+            },
+        )
+
+        service = SubscriptionSyncService()
+        channel_id = str(channel.pk)
+
+        # Delete the channel to simulate deletion during sync
+        channel.delete()
+
+        result = service.sync_channel(channel_id)
+
+        # Should not crash — channel not found returns False
+        assert result is False
+
+
+EMPTY_ICS = (
+    b"BEGIN:VCALENDAR\r\nVERSION:2.0\r\n"
+    b"PRODID:-//Test//Test//EN\r\n"
+    b"END:VCALENDAR"
+)
+
+LATIN1_ICS = (
+    "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//Test//EN\r\n"
+    "BEGIN:VEVENT\r\nUID:latin1-event@test\r\n"
+    "DTSTART:20260101T100000Z\r\nDTEND:20260101T110000Z\r\n"
+    "SUMMARY:R\u00e9union d'\u00e9quipe\r\n"
+    "LOCATION:Caf\u00e9 des Arts\r\n"
+    "END:VEVENT\r\nEND:VCALENDAR"
+).encode("latin-1")
+
+
+class TestEmptyIcsProtection:
+    """Tests for empty ICS protection (#7)."""
+
+    def test_empty_ics_refuses_to_delete_all(self):
+        """Sync with 0 new events but existing events should raise."""
+        service = SubscriptionSyncService()
+
+        # Mock existing events in SabreDAV
+        mock_event = MagicMock()
+        mock_event.icalendar_component.get.return_value = "existing-uid"
+        mock_event.url.path = "/calendars/users/test/uuid/existing.ics"
+        mock_event.data = "BEGIN:VCALENDAR\r\nEND:VCALENDAR"
+
+        mock_calendar = MagicMock()
+        mock_calendar.events.return_value = [mock_event]
+
+        mock_client = MagicMock()
+        mock_client.calendar.return_value = mock_calendar
+
+        with patch.object(service._http, "get_dav_client", return_value=mock_client):
+            with pytest.raises(ValueError, match="refusing to delete all events"):
+                service._sync_events(
+                    MagicMock(), "/calendars/users/test/uuid/", EMPTY_ICS
+                )
+
+    def test_empty_ics_on_empty_calendar_ok(self):
+        """Sync with 0 new events and 0 existing events should not raise."""
+        service = SubscriptionSyncService()
+
+        mock_calendar = MagicMock()
+        mock_calendar.events.return_value = []
+
+        mock_client = MagicMock()
+        mock_client.calendar.return_value = mock_calendar
+
+        with patch.object(service._http, "get_dav_client", return_value=mock_client):
+            result = service._sync_events(
+                MagicMock(), "/calendars/users/test/uuid/", EMPTY_ICS
+            )
+
+        assert result.created == 0
+        assert result.deleted == 0
+        assert result.unchanged == 0
+
+
+class TestIcsEncodingFallback:
+    """Tests for non-UTF-8 ICS encoding (#9)."""
+
+    def test_normalize_utf8_unchanged(self):
+        """Valid UTF-8 data should pass through unchanged."""
+        result = SubscriptionSyncService._normalize_ics_encoding(VALID_ICS)
+        assert result == VALID_ICS
+
+    def test_normalize_latin1_to_utf8(self):
+        """Latin-1 encoded ICS should be converted to UTF-8."""
+        result = SubscriptionSyncService._normalize_ics_encoding(LATIN1_ICS)
+        # Should now be valid UTF-8
+        decoded = result.decode("utf-8")
+        assert "Réunion" in decoded
+        assert "Café" in decoded
+
+    def test_parse_latin1_ics(self):
+        """Latin-1 ICS with accented characters should parse correctly."""
+        service = SubscriptionSyncService()
+        events = service._parse_ics_events(LATIN1_ICS)
+        assert "latin1-event@test" in events
+        assert "union" in events["latin1-event@test"]  # Réunion

--- a/src/backend/core/tests/test_subscription_sync.py
+++ b/src/backend/core/tests/test_subscription_sync.py
@@ -225,7 +225,6 @@ class TestSyncChannel:
     def test_sync_survives_channel_deletion(self, mock_cache, mock_fetch):
         """If channel is deleted during sync, save should not crash."""
         mock_cache.add.return_value = True
-        mock_fetch.return_value = (304, None, '"etag"', "date")
 
         user = UserFactory()
         channel = Channel.objects.create(
@@ -246,12 +245,20 @@ class TestSyncChannel:
         service = SubscriptionSyncService()
         channel_id = str(channel.pk)
 
-        # Delete the channel to simulate deletion during sync
-        channel.delete()
+        # Delete the row *during* sync, after the channel has already
+        # been loaded into memory — this exercises the real race that
+        # _save_channel's existence check is meant to handle, unlike a
+        # pre-sync delete which only hits the "not found" branch.
+        def delete_during_fetch(*_args, **_kwargs):
+            Channel.objects.filter(pk=channel.pk).delete()
+            return (304, None, '"etag"', "date")
+
+        mock_fetch.side_effect = delete_during_fetch
 
         result = service.sync_channel(channel_id)
 
-        # Should not crash — channel not found returns False
+        # _save_channel's existence check must catch the deletion and
+        # propagate False up through sync_channel.
         assert result is False
 
 

--- a/src/backend/core/tests/test_subscription_sync.py
+++ b/src/backend/core/tests/test_subscription_sync.py
@@ -1,15 +1,14 @@
 """Tests for subscription sync service."""
 
+# pylint: disable=missing-class-docstring,missing-function-docstring,protected-access
+
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from core.factories import UserFactory
 from core.models import Channel
-from core.services.subscription_sync_service import (
-    SubscriptionSyncService,
-    SyncResult,
-)
+from core.services.subscription_sync_service import SubscriptionSyncService
 from core.services.url_validation import URLValidationError
 
 VALID_ICS = (
@@ -257,9 +256,7 @@ class TestSyncChannel:
 
 
 EMPTY_ICS = (
-    b"BEGIN:VCALENDAR\r\nVERSION:2.0\r\n"
-    b"PRODID:-//Test//Test//EN\r\n"
-    b"END:VCALENDAR"
+    b"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//Test//EN\r\nEND:VCALENDAR"
 )
 
 LATIN1_ICS = (

--- a/src/backend/core/tests/test_subscription_tasks.py
+++ b/src/backend/core/tests/test_subscription_tasks.py
@@ -1,0 +1,107 @@
+"""Tests for subscription sync Dramatiq tasks."""
+
+from unittest.mock import patch
+
+from django.utils import timezone
+
+import pytest
+
+from core.factories import UserFactory
+from core.models import Channel
+from core.tasks import sync_all_subscriptions
+
+
+@pytest.mark.django_db
+class TestSyncAllSubscriptions:
+    @patch("core.tasks.sync_one_subscription")
+    def test_dispatches_for_active_channels(self, mock_sync_one):
+        """Should dispatch one task per active subscription channel."""
+        user = UserFactory()
+        Channel.objects.create(
+            name="Sub 1",
+            type="ical-subscription",
+            user=user,
+            is_active=True,
+            caldav_path="/calendars/users/test@test.com/uuid1/",
+            settings={
+                "source_url": "https://example.com/1.ics",
+                "sync_interval": 300,
+                "last_sync_status": "ok",
+                "error_count": 0,
+            },
+        )
+        Channel.objects.create(
+            name="Sub 2",
+            type="ical-subscription",
+            user=user,
+            is_active=True,
+            caldav_path="/calendars/users/test@test.com/uuid2/",
+            settings={
+                "source_url": "https://example.com/2.ics",
+                "sync_interval": 300,
+                "last_sync_status": "ok",
+                "error_count": 0,
+            },
+        )
+
+        result = sync_all_subscriptions()
+        assert result == 2
+        assert mock_sync_one.send_with_options.call_count == 2
+
+    @patch("core.tasks.sync_one_subscription")
+    def test_skips_inactive_channels(self, mock_sync_one):
+        """Should not dispatch for inactive channels."""
+        user = UserFactory()
+        Channel.objects.create(
+            name="Inactive Sub",
+            type="ical-subscription",
+            user=user,
+            is_active=False,
+            caldav_path="/calendars/users/test@test.com/uuid/",
+            settings={
+                "source_url": "https://example.com/cal.ics",
+                "sync_interval": 300,
+                "error_count": 3,
+            },
+        )
+
+        result = sync_all_subscriptions()
+        assert result == 0
+        assert mock_sync_one.send_with_options.call_count == 0
+
+    @patch("core.tasks.sync_one_subscription")
+    def test_skips_non_subscription_channels(self, mock_sync_one):
+        """Should not dispatch for ical-feed or caldav channels."""
+        user = UserFactory()
+        Channel.objects.create(
+            name="Feed",
+            type="ical-feed",
+            user=user,
+            is_active=True,
+            caldav_path="/calendars/users/test@test.com/uuid/",
+            settings={"role": "reader"},
+        )
+
+        result = sync_all_subscriptions()
+        assert result == 0
+
+    @patch("core.tasks.sync_one_subscription")
+    def test_skips_recently_synced(self, mock_sync_one):
+        """Should skip channels that were synced recently."""
+        user = UserFactory()
+        Channel.objects.create(
+            name="Recent Sub",
+            type="ical-subscription",
+            user=user,
+            is_active=True,
+            caldav_path="/calendars/users/test@test.com/uuid/",
+            settings={
+                "source_url": "https://example.com/cal.ics",
+                "sync_interval": 300,
+                "last_sync_at": timezone.now().isoformat(),
+                "error_count": 0,
+            },
+        )
+
+        result = sync_all_subscriptions()
+        assert result == 0

--- a/src/backend/core/tests/test_subscription_tasks.py
+++ b/src/backend/core/tests/test_subscription_tasks.py
@@ -1,5 +1,7 @@
 """Tests for subscription sync Dramatiq tasks."""
 
+# pylint: disable=missing-class-docstring,unused-argument
+
 from unittest.mock import patch
 
 from django.utils import timezone

--- a/src/backend/core/tests/test_url_validation.py
+++ b/src/backend/core/tests/test_url_validation.py
@@ -1,0 +1,269 @@
+"""Tests for URL validation service."""
+
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from core.services.url_validation import (
+    URLValidationError,
+    fetch_ics,
+    normalize_url,
+    validate_subscription_url,
+)
+
+VALID_ICS = b"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR"
+
+
+class TestNormalizeUrl:
+    def test_webcal_to_https(self):
+        assert (
+            normalize_url("webcal://example.com/cal.ics")
+            == "https://example.com/cal.ics"
+        )
+
+    def test_webcal_case_insensitive(self):
+        assert (
+            normalize_url("WEBCAL://example.com/cal.ics")
+            == "https://example.com/cal.ics"
+        )
+
+    def test_https_unchanged(self):
+        assert (
+            normalize_url("https://example.com/cal.ics")
+            == "https://example.com/cal.ics"
+        )
+
+    def test_strips_whitespace(self):
+        assert (
+            normalize_url("  https://example.com/cal.ics  ")
+            == "https://example.com/cal.ics"
+        )
+
+
+class TestValidateSubscriptionUrl:
+    @patch("core.services.url_validation._resolve_and_check")
+    def test_valid_https_url(self, mock_resolve):
+        mock_resolve.return_value = "93.184.216.34"
+        result = validate_subscription_url("https://example.com/cal.ics")
+        assert result == "https://example.com/cal.ics"
+
+    def test_rejects_http(self):
+        with pytest.raises(URLValidationError, match="Only HTTPS URLs are allowed"):
+            validate_subscription_url("http://example.com/cal.ics")
+
+    @patch("core.services.url_validation._resolve_and_check")
+    def test_normalizes_webcal(self, mock_resolve):
+        mock_resolve.return_value = "93.184.216.34"
+        result = validate_subscription_url("webcal://example.com/cal.ics")
+        assert result == "https://example.com/cal.ics"
+
+    def test_rejects_empty_hostname(self):
+        with pytest.raises(URLValidationError):
+            validate_subscription_url("https:///no-host")
+
+    @patch(
+        "core.services.url_validation._resolve_and_check",
+        side_effect=URLValidationError("URL resolves to a private network address"),
+    )
+    def test_rejects_private_ip(self, _mock):
+        with pytest.raises(URLValidationError, match="private network"):
+            validate_subscription_url("https://internal.local/cal.ics")
+
+
+class TestResolveAndCheck:
+    @patch("core.services.url_validation.socket.getaddrinfo")
+    def test_rejects_loopback(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+        ]
+        with pytest.raises(URLValidationError, match="private network"):
+            validate_subscription_url("https://localhost/cal.ics")
+
+    @patch("core.services.url_validation.socket.getaddrinfo")
+    def test_rejects_10_network(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("10.0.0.1", 0)),
+        ]
+        with pytest.raises(URLValidationError, match="private network"):
+            validate_subscription_url("https://internal.example.com/cal.ics")
+
+    @patch("core.services.url_validation.socket.getaddrinfo")
+    def test_rejects_172_16_network(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("172.16.0.1", 0)),
+        ]
+        with pytest.raises(URLValidationError, match="private network"):
+            validate_subscription_url("https://internal.example.com/cal.ics")
+
+    @patch("core.services.url_validation.socket.getaddrinfo")
+    def test_rejects_192_168_network(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("192.168.1.1", 0)),
+        ]
+        with pytest.raises(URLValidationError, match="private network"):
+            validate_subscription_url("https://router.local/cal.ics")
+
+    @patch("core.services.url_validation.socket.getaddrinfo")
+    def test_rejects_link_local(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("169.254.1.1", 0)),
+        ]
+        with pytest.raises(URLValidationError, match="private network"):
+            validate_subscription_url("https://metadata.local/cal.ics")
+
+    @patch("core.services.url_validation.socket.getaddrinfo")
+    def test_rejects_ipv6_loopback(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (10, 1, 6, "", ("::1", 0, 0, 0)),
+        ]
+        with pytest.raises(URLValidationError, match="private network"):
+            validate_subscription_url("https://ipv6-local.example.com/cal.ics")
+
+    @patch("core.services.url_validation.socket.getaddrinfo")
+    def test_accepts_public_ip(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("93.184.216.34", 0)),
+        ]
+        result = validate_subscription_url("https://example.com/cal.ics")
+        assert result == "https://example.com/cal.ics"
+
+    @patch(
+        "core.services.url_validation.socket.getaddrinfo",
+        side_effect=socket.gaierror("Name resolution failed"),
+    )
+    def test_rejects_unresolvable(self, _mock):
+        with pytest.raises(URLValidationError, match="Cannot resolve"):
+            validate_subscription_url("https://nonexistent.invalid/cal.ics")
+
+
+class TestFetchIcs:
+    @patch("core.services.url_validation._resolve_and_check")
+    @patch("core.services.url_validation.requests.get")
+    def test_200_returns_ics_data(self, mock_get, mock_resolve):
+        mock_resolve.return_value = "93.184.216.34"
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {
+            "Content-Type": "text/calendar",
+            "ETag": '"abc123"',
+            "Last-Modified": "Wed, 01 Jan 2026 00:00:00 GMT",
+        }
+        mock_response.iter_content.return_value = [VALID_ICS]
+        mock_get.return_value = mock_response
+
+        status_code, data, etag, last_mod = fetch_ics("https://example.com/cal.ics")
+        assert status_code == 200
+        assert data == VALID_ICS
+        assert etag == '"abc123"'
+        assert last_mod == "Wed, 01 Jan 2026 00:00:00 GMT"
+
+    @patch("core.services.url_validation._resolve_and_check")
+    @patch("core.services.url_validation.requests.get")
+    def test_304_returns_none_data(self, mock_get, mock_resolve):
+        mock_resolve.return_value = "93.184.216.34"
+        mock_response = MagicMock()
+        mock_response.status_code = 304
+        mock_get.return_value = mock_response
+
+        status_code, data, etag, last_mod = fetch_ics(
+            "https://example.com/cal.ics", etag='"old"', last_modified="old-date"
+        )
+        assert status_code == 304
+        assert data is None
+        assert etag == '"old"'
+
+    @patch("core.services.url_validation._resolve_and_check")
+    @patch("core.services.url_validation.requests.get")
+    def test_sends_conditional_headers(self, mock_get, mock_resolve):
+        mock_resolve.return_value = "93.184.216.34"
+        mock_response = MagicMock()
+        mock_response.status_code = 304
+        mock_get.return_value = mock_response
+
+        fetch_ics(
+            "https://example.com/cal.ics",
+            etag='"etag-val"',
+            last_modified="last-mod-val",
+        )
+
+        call_kwargs = mock_get.call_args
+        assert call_kwargs[1]["headers"]["If-None-Match"] == '"etag-val"'
+        assert call_kwargs[1]["headers"]["If-Modified-Since"] == "last-mod-val"
+
+    @patch("core.services.url_validation._resolve_and_check")
+    @patch("core.services.url_validation.requests.get")
+    def test_rejects_non_ics_content(self, mock_get, mock_resolve):
+        mock_resolve.return_value = "93.184.216.34"
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "text/html"}
+        mock_response.iter_content.return_value = [b"<html>Not a calendar</html>"]
+        mock_get.return_value = mock_response
+
+        with pytest.raises(URLValidationError, match="valid calendar data"):
+            fetch_ics("https://example.com/cal.ics")
+
+    @patch("core.services.url_validation._resolve_and_check")
+    @patch("core.services.url_validation.requests.get")
+    def test_rejects_oversized_response(self, mock_get, mock_resolve):
+        mock_resolve.return_value = "93.184.216.34"
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "text/calendar"}
+        # Return chunks that exceed 10 MB
+        big_chunk = b"x" * (5 * 1024 * 1024)
+        mock_response.iter_content.return_value = [big_chunk, big_chunk, big_chunk]
+        mock_get.return_value = mock_response
+
+        with pytest.raises(URLValidationError, match="too large"):
+            fetch_ics("https://example.com/cal.ics")
+
+    @patch("core.services.url_validation._resolve_and_check")
+    @patch(
+        "core.services.url_validation.requests.get",
+        side_effect=requests.exceptions.Timeout("timed out"),
+    )
+    def test_timeout_raises(self, _mock_get, mock_resolve):
+        mock_resolve.return_value = "93.184.216.34"
+        with pytest.raises(URLValidationError, match="timed out"):
+            fetch_ics("https://example.com/cal.ics")
+
+    @patch("core.services.url_validation._resolve_and_check")
+    @patch("core.services.url_validation.requests.get")
+    def test_http_error_raises(self, mock_get, mock_resolve):
+        mock_resolve.return_value = "93.184.216.34"
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        with pytest.raises(URLValidationError, match="HTTP 404"):
+            fetch_ics("https://example.com/cal.ics")
+
+    @patch("core.services.url_validation._resolve_and_check")
+    @patch("core.services.url_validation.requests.get")
+    def test_redirect_to_private_ip_blocked(self, mock_get, mock_resolve):
+        mock_resolve.side_effect = [
+            "93.184.216.34",  # initial URL check
+            URLValidationError("URL resolves to a private network address"),  # redirect
+        ]
+        mock_response = MagicMock()
+        mock_response.status_code = 302
+        mock_response.headers = {"Location": "https://evil.internal/cal.ics"}
+        mock_get.return_value = mock_response
+
+        with pytest.raises(URLValidationError, match="private network"):
+            fetch_ics("https://example.com/cal.ics")
+
+    @patch("core.services.url_validation._resolve_and_check")
+    @patch("core.services.url_validation.requests.get")
+    def test_too_many_redirects(self, mock_get, mock_resolve):
+        mock_resolve.return_value = "93.184.216.34"
+        mock_response = MagicMock()
+        mock_response.status_code = 302
+        mock_response.headers = {"Location": "https://example.com/redirect"}
+        mock_get.return_value = mock_response
+
+        with pytest.raises(URLValidationError, match="Too many redirects"):
+            fetch_ics("https://example.com/cal.ics")

--- a/src/backend/core/tests/test_url_validation.py
+++ b/src/backend/core/tests/test_url_validation.py
@@ -1,5 +1,7 @@
 """Tests for URL validation service."""
 
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
 import socket
 from unittest.mock import MagicMock, patch
 
@@ -167,7 +169,7 @@ class TestFetchIcs:
         mock_response.status_code = 304
         mock_get.return_value = mock_response
 
-        status_code, data, etag, last_mod = fetch_ics(
+        status_code, data, etag, _last_mod = fetch_ics(
             "https://example.com/cal.ics", etag='"old"', last_modified="old-date"
         )
         assert status_code == 304

--- a/src/frontend/apps/calendars/src/features/calendar/api.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/api.ts
@@ -2,6 +2,7 @@
  * API functions for calendar operations.
  */
 
+import { APIError } from "@/features/api/APIError";
 import { fetchAPI } from "@/features/api/fetchApi";
 
 /**
@@ -58,8 +59,8 @@ export const getICalFeedChannel = async (
     const match = channels.find((c) => c.caldav_path === caldavPath) ?? null;
     return { success: true, channel: match };
   } catch (error) {
-    if (error && typeof error === "object" && "status" in error) {
-      const status = error.status as number;
+    if (error instanceof APIError) {
+      const status = error.code;
       if (status === 403) {
         return {
           success: false,
@@ -116,6 +117,115 @@ export const deleteChannel = async (channelId: string): Promise<void> => {
     method: "DELETE",
   });
 };
+
+// ============================================================================
+// Subscription Channel API
+// ============================================================================
+
+/**
+ * Subscription channel response from the API.
+ */
+export interface SubscriptionChannel {
+  id: string;
+  name: string;
+  type: "ical-subscription";
+  caldav_path: string;
+  is_active: boolean;
+  source_url: string;
+  last_sync_at: string | null;
+  last_sync_status: "pending" | "ok" | "error";
+  last_sync_error: string;
+  error_count: number;
+  sync_interval: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Get all subscription channels for the current user.
+ */
+export const getSubscriptionChannels = async (): Promise<
+  SubscriptionChannel[]
+> => {
+  const response = await fetchAPI(`channels/?type=ical-subscription`, {
+    method: "GET",
+  });
+  return response.json();
+};
+
+/**
+ * Create a subscription channel.
+ */
+export const createSubscriptionChannel = async (params: {
+  name: string;
+  sourceUrl: string;
+  color?: string;
+}): Promise<SubscriptionChannel> => {
+  const body: Record<string, string> = {
+    name: params.name,
+    type: "ical-subscription",
+    source_url: params.sourceUrl,
+  };
+  if (params.color) {
+    body.color = params.color;
+  }
+  const response = await fetchAPI("channels/", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  return response.json();
+};
+
+/**
+ * Update a subscription channel (name and/or source URL).
+ */
+export const updateSubscriptionChannel = async (
+  channelId: string,
+  params: { name?: string; sourceUrl?: string; color?: string },
+): Promise<SubscriptionChannel> => {
+  const body: Record<string, string> = {};
+  if (params.name !== undefined) {
+    body.name = params.name;
+  }
+  if (params.sourceUrl !== undefined) {
+    body.source_url = params.sourceUrl;
+  }
+  if (params.color !== undefined) {
+    body.color = params.color;
+  }
+  const response = await fetchAPI(`channels/${channelId}/`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+  return response.json();
+};
+
+/**
+ * Delete a subscription channel by ID.
+ */
+export const deleteSubscriptionChannel = async (
+  channelId: string,
+): Promise<void> => {
+  await fetchAPI(`channels/${channelId}/`, {
+    method: "DELETE",
+  });
+};
+
+/**
+ * Reactivate a stopped subscription channel.
+ */
+export const reactivateSubscriptionChannel = async (
+  channelId: string,
+): Promise<SubscriptionChannel> => {
+  const response = await fetchAPI(`channels/${channelId}/reactivate/`, {
+    method: "POST",
+  });
+  return response.json();
+};
+
+// ============================================================================
+// ICS Import API
+// ============================================================================
 
 /**
  * Result of an ICS import operation.

--- a/src/frontend/apps/calendars/src/features/calendar/api.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/api.ts
@@ -133,7 +133,7 @@ export interface SubscriptionChannel {
   is_active: boolean;
   source_url: string;
   last_sync_at: string | null;
-  last_sync_status: "pending" | "ok" | "error";
+  last_sync_status: "pending" | "ok" | "error" | "stopped";
   last_sync_error: string;
   error_count: number;
   sync_interval: number;

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/AddSubscriptionModal.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/AddSubscriptionModal.tsx
@@ -1,0 +1,118 @@
+/**
+ * AddSubscriptionModal component.
+ * Simple modal with a URL input to add an external calendar subscription.
+ */
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button, Modal, ModalSize, Input } from "@gouvfr-lasuite/cunningham-react";
+import { Spinner } from "@gouvfr-lasuite/ui-kit";
+
+import { useCreateSubscriptionChannel } from "../../hooks/useCalendars";
+import { ColorPicker } from "./ColorPicker";
+import { DEFAULT_COLORS } from "./constants";
+
+interface AddSubscriptionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+export const AddSubscriptionModal = ({
+  isOpen,
+  onClose,
+  onSuccess,
+}: AddSubscriptionModalProps) => {
+  const { t } = useTranslation();
+  const [url, setUrl] = useState("");
+  const [name, setName] = useState("");
+  const [color, setColor] = useState(DEFAULT_COLORS[0]);
+  const createMutation = useCreateSubscriptionChannel();
+
+  const handleSubmit = async () => {
+    if (!url.trim()) return;
+
+    try {
+      await createMutation.mutateAsync({
+        name: name.trim() || url.trim(),
+        sourceUrl: url.trim(),
+        color,
+      });
+      setUrl("");
+      setName("");
+      setColor(DEFAULT_COLORS[0]);
+      onSuccess?.();
+      onClose();
+    } catch {
+      // Error is available via createMutation.error
+    }
+  };
+
+  const handleClose = () => {
+    setUrl("");
+    setName("");
+    setColor(DEFAULT_COLORS[0]);
+    createMutation.reset();
+    onClose();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      size={ModalSize.MEDIUM}
+      title={t("calendar.subscription.add.title")}
+      actions={
+        <>
+          <Button
+            color="neutral"
+            onClick={handleClose}
+            disabled={createMutation.isPending}
+          >
+            {t("common.cancel")}
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!url.trim() || createMutation.isPending}
+          >
+            {createMutation.isPending ? (
+              <Spinner />
+            ) : (
+              t("calendar.subscription.add.submit")
+            )}
+          </Button>
+        </>
+      }
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <p className="calendar-modal__description">
+          {t("calendar.subscription.add.description")}
+        </p>
+
+        <Input
+          label={t("calendar.subscription.add.urlLabel")}
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://example.com/calendar.ics"
+          fullWidth
+          state={createMutation.isError ? "error" : "default"}
+          text={
+            createMutation.isError
+              ? t("calendar.subscription.add.error")
+              : undefined
+          }
+        />
+
+        <Input
+          label={t("calendar.subscription.add.nameLabel")}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={t("calendar.subscription.add.namePlaceholder")}
+          fullWidth
+        />
+
+        <ColorPicker value={color} onChange={setColor} />
+      </div>
+    </Modal>
+  );
+};

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarList.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarList.tsx
@@ -3,20 +3,27 @@
  * Shows onboarding modal when user has no calendars.
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useCalendarContext } from "../../contexts";
 import { setupCalendar } from "@/features/mailbox/api";
+import {
+  useSubscriptionChannels,
+  useDeleteSubscriptionChannel,
+  useReactivateSubscriptionChannel,
+} from "../../hooks/useCalendars";
 
 import { CalendarModal } from "./CalendarModal";
 import { CalendarShareModal } from "./CalendarShareModal";
 import { DeleteConfirmModal } from "./DeleteConfirmModal";
 import { ImportEventsModal } from "./ImportEventsModal";
 import { SubscriptionUrlModal } from "./SubscriptionUrlModal";
+import { SubscriptionCalendarSection } from "./SubscriptionCalendarSection";
 import { CalendarListItem } from "./CalendarListItem";
 import { useCalendarListState } from "./hooks/useCalendarListState";
 import type { CalDavCalendar } from "../../services/dav/types/caldav-service";
+import type { SubscriptionChannel } from "../../api";
 import { extractCaldavPath } from "./utils";
 
 export const CalendarList = () => {
@@ -129,6 +136,81 @@ export const CalendarList = () => {
     }
   }, [calendarRef]);
 
+  const handleSubscriptionRefresh = useCallback(async () => {
+    await refreshCalendars();
+    if (calendarRef.current) {
+      calendarRef.current.refetchEvents();
+    }
+  }, [refreshCalendars, calendarRef]);
+
+  // Subscription channels
+  const { data: subscriptionChannels = [] } = useSubscriptionChannels();
+  const deleteSubMutation = useDeleteSubscriptionChannel();
+  const reactivateSubMutation = useReactivateSubscriptionChannel();
+
+  // Separate subscription calendars from owned calendars
+  const subscriptionPaths = useMemo(
+    () => new Set(subscriptionChannels.map((ch) => ch.caldav_path)),
+    [subscriptionChannels],
+  );
+
+  const [deletingPaths, setDeletingPaths] = useState<Set<string>>(new Set());
+
+  const { regularCalendars, subscriptionCalendars } = useMemo(() => {
+    const regular: CalDavCalendar[] = [];
+    const subscription: CalDavCalendar[] = [];
+    for (const cal of ownedCalendars) {
+      const calPath = extractCaldavPath(cal.url);
+      if (calPath && deletingPaths.has(calPath)) continue;
+      if (calPath && subscriptionPaths.has(calPath)) {
+        subscription.push(cal);
+      } else {
+        regular.push(cal);
+      }
+    }
+    // Sort by channel creation date (oldest first = order of addition)
+    subscription.sort((a, b) => {
+      const pathA = extractCaldavPath(a.url);
+      const pathB = extractCaldavPath(b.url);
+      const chA = subscriptionChannels.find(
+        (ch) => pathA === ch.caldav_path,
+      );
+      const chB = subscriptionChannels.find(
+        (ch) => pathB === ch.caldav_path,
+      );
+      if (!chA || !chB) return 0;
+      return (
+        new Date(chA.created_at).getTime() -
+        new Date(chB.created_at).getTime()
+      );
+    });
+    return { regularCalendars: regular, subscriptionCalendars: subscription };
+  }, [ownedCalendars, subscriptionPaths, subscriptionChannels, deletingPaths]);
+
+  const handleDeleteSubscription = useCallback(
+    async (channel: SubscriptionChannel) => {
+      setDeletingPaths((prev) => new Set(prev).add(channel.caldav_path));
+      try {
+        await deleteSubMutation.mutateAsync(channel.id);
+        await refreshCalendars();
+      } finally {
+        setDeletingPaths((prev) => {
+          const next = new Set(prev);
+          next.delete(channel.caldav_path);
+          return next;
+        });
+      }
+    },
+    [deleteSubMutation, refreshCalendars],
+  );
+
+  const handleReactivateSubscription = useCallback(
+    async (channel: SubscriptionChannel) => {
+      await reactivateSubMutation.mutateAsync(channel.id);
+    },
+    [reactivateSubMutation],
+  );
+
   return (
     <>
       <div className="calendar-list">
@@ -162,7 +244,7 @@ export const CalendarList = () => {
           </div>
           {isMyCalendarsExpanded && (
             <div className="calendar-list__items">
-              {ownedCalendars.map((calendar) => (
+              {regularCalendars.map((calendar) => (
                 <CalendarListItem
                   key={calendar.url}
                   calendar={calendar}
@@ -182,6 +264,16 @@ export const CalendarList = () => {
             </div>
           )}
         </div>
+
+        <SubscriptionCalendarSection
+          calendars={subscriptionCalendars}
+          channels={subscriptionChannels}
+          visibleCalendarUrls={visibleCalendarUrls}
+          onToggleVisibility={toggleCalendarVisibility}
+          onDelete={handleDeleteSubscription}
+          onReactivate={handleReactivateSubscription}
+          onRefresh={handleSubscriptionRefresh}
+        />
 
         {sharedCalendars.length > 0 && (
           <div className="calendar-list__section">

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarModal.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarModal.tsx
@@ -23,6 +23,7 @@ import { useMailboxContext } from "@/features/mailbox/MailboxContext";
 
 import { FeatureFlag, useFeatureFlag } from "@/hooks/useFeatureFlag";
 import { DEFAULT_COLORS } from "./constants";
+import { ColorPicker } from "./ColorPicker";
 import type { CalendarModalProps } from "./types";
 
 const NO_MAILBOX_VALUE = "__none__";
@@ -264,25 +265,7 @@ export const CalendarModal = ({
           fullWidth
         />
 
-        <div className="calendar-modal__field">
-          <label className="calendar-modal__label">
-            {t("calendar.createCalendar.color")}
-          </label>
-          <div className="calendar-modal__colors">
-            {DEFAULT_COLORS.map((c) => (
-              <button
-                key={c}
-                type="button"
-                className={`calendar-modal__color-btn ${
-                  color === c ? "calendar-modal__color-btn--selected" : ""
-                }`}
-                style={{ backgroundColor: c }}
-                onClick={() => setColor(c)}
-                aria-label={c}
-              />
-            ))}
-          </div>
-        </div>
+        <ColorPicker value={color} onChange={setColor} />
 
         {mode === "edit" && availabilitiesEnabled && (
           <label style={{ display: "flex", alignItems: "center", gap: "8px", padding: "8px 0", cursor: "pointer" }}>

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/ColorPicker.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/ColorPicker.tsx
@@ -1,0 +1,39 @@
+/**
+ * ColorPicker component.
+ * Displays a palette of color buttons for calendar color selection.
+ */
+
+import { useTranslation } from "react-i18next";
+
+import { DEFAULT_COLORS } from "./constants";
+
+interface ColorPickerProps {
+  value: string;
+  onChange: (color: string) => void;
+}
+
+export const ColorPicker = ({ value, onChange }: ColorPickerProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="calendar-modal__field">
+      <label className="calendar-modal__label">
+        {t("calendar.createCalendar.color")}
+      </label>
+      <div className="calendar-modal__colors">
+        {DEFAULT_COLORS.map((c) => (
+          <button
+            key={c}
+            type="button"
+            className={`calendar-modal__color-btn ${
+              value === c ? "calendar-modal__color-btn--selected" : ""
+            }`}
+            style={{ backgroundColor: c }}
+            onClick={() => onChange(c)}
+            aria-label={c}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/EditSubscriptionModal.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/EditSubscriptionModal.tsx
@@ -1,0 +1,146 @@
+/**
+ * EditSubscriptionModal component.
+ * Modal for editing a subscription channel's name, source URL, and color.
+ */
+
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  Input,
+  Modal,
+  ModalSize,
+} from "@gouvfr-lasuite/cunningham-react";
+import { Spinner } from "@gouvfr-lasuite/ui-kit";
+
+import { useUpdateSubscriptionChannel } from "../../hooks/useCalendars";
+import type { SubscriptionChannel } from "../../api";
+import { ColorPicker } from "./ColorPicker";
+import { DEFAULT_COLORS } from "./constants";
+
+interface EditSubscriptionModalProps {
+  isOpen: boolean;
+  channel: SubscriptionChannel | null;
+  calendarColor?: string;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+export const EditSubscriptionModal = ({
+  isOpen,
+  channel,
+  calendarColor,
+  onClose,
+  onSuccess,
+}: EditSubscriptionModalProps) => {
+  const { t } = useTranslation();
+  const [name, setName] = useState("");
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [color, setColor] = useState(DEFAULT_COLORS[0]);
+  const updateMutation = useUpdateSubscriptionChannel();
+
+  useEffect(() => {
+    if (isOpen && channel) {
+      setName(channel.name ?? "");
+      setSourceUrl(channel.source_url ?? "");
+      setColor(calendarColor || DEFAULT_COLORS[0]);
+      updateMutation.reset();
+    }
+  }, [isOpen, channel]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSubmit = async () => {
+    if (!channel || !name.trim() || !sourceUrl.trim()) return;
+
+    const params: { name?: string; sourceUrl?: string; color?: string } = {};
+
+    if (name.trim() !== channel.name) {
+      params.name = name.trim();
+    }
+    if (sourceUrl.trim() !== channel.source_url) {
+      params.sourceUrl = sourceUrl.trim();
+    }
+    if (color !== (calendarColor || DEFAULT_COLORS[0])) {
+      params.color = color;
+    }
+
+    if (Object.keys(params).length === 0) {
+      onClose();
+      return;
+    }
+
+    try {
+      await updateMutation.mutateAsync({
+        channelId: channel.id,
+        params,
+      });
+      onSuccess?.();
+      onClose();
+    } catch {
+      // Error is available via updateMutation.error
+    }
+  };
+
+  const handleClose = () => {
+    updateMutation.reset();
+    onClose();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      size={ModalSize.MEDIUM}
+      title={t("calendar.subscription.edit.title")}
+      actions={
+        <>
+          <Button
+            color="neutral"
+            onClick={handleClose}
+            disabled={updateMutation.isPending}
+          >
+            {t("common.cancel")}
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={
+              !name.trim() ||
+              !sourceUrl.trim() ||
+              updateMutation.isPending
+            }
+          >
+            {updateMutation.isPending ? (
+              <Spinner />
+            ) : (
+              t("calendar.subscription.edit.save")
+            )}
+          </Button>
+        </>
+      }
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <Input
+          label={t("calendar.subscription.add.nameLabel")}
+          value={name}
+          onChange={(e) => setName(e.target.value ?? "")}
+          fullWidth
+        />
+
+        <Input
+          label={t("calendar.subscription.add.urlLabel")}
+          value={sourceUrl}
+          onChange={(e) => setSourceUrl(e.target.value ?? "")}
+          placeholder="https://example.com/calendar.ics"
+          fullWidth
+          state={updateMutation.isError ? "error" : "default"}
+          text={
+            updateMutation.isError
+              ? t("calendar.subscription.edit.error")
+              : undefined
+          }
+        />
+
+        <ColorPicker value={color} onChange={setColor} />
+      </div>
+    </Modal>
+  );
+};

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/EditSubscriptionModal.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/EditSubscriptionModal.tsx
@@ -15,6 +15,7 @@ import { Spinner } from "@gouvfr-lasuite/ui-kit";
 
 import { useUpdateSubscriptionChannel } from "../../hooks/useCalendars";
 import type { SubscriptionChannel } from "../../api";
+import { errorToString } from "@/features/api/APIError";
 import { ColorPicker } from "./ColorPicker";
 import { DEFAULT_COLORS } from "./constants";
 
@@ -134,7 +135,8 @@ export const EditSubscriptionModal = ({
           state={updateMutation.isError ? "error" : "default"}
           text={
             updateMutation.isError
-              ? t("calendar.subscription.edit.error")
+              ? errorToString(updateMutation.error) ||
+                t("calendar.subscription.edit.error")
               : undefined
           }
         />

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/SubscriptionCalendarSection.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/SubscriptionCalendarSection.tsx
@@ -1,0 +1,176 @@
+/**
+ * SubscriptionCalendarSection component.
+ * Displays subscription calendars in a separate section with sync status.
+ */
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { CalDavCalendar } from "../../services/dav/types/caldav-service";
+import type { SubscriptionChannel } from "../../api";
+import { MAX_SUBSCRIPTIONS_PER_USER } from "../../config";
+import { CalendarListItem } from "./CalendarListItem";
+import { AddSubscriptionModal } from "./AddSubscriptionModal";
+import { EditSubscriptionModal } from "./EditSubscriptionModal";
+import { SubscriptionStatusBadge } from "./SubscriptionStatusBadge";
+import { extractCaldavPath } from "./utils";
+
+interface SubscriptionCalendarSectionProps {
+  calendars: CalDavCalendar[];
+  channels: SubscriptionChannel[];
+  visibleCalendarUrls: Set<string>;
+  onToggleVisibility: (url: string) => void;
+  onDelete: (channel: SubscriptionChannel) => void;
+  onReactivate: (channel: SubscriptionChannel) => void;
+  onRefresh: () => void;
+}
+
+export const SubscriptionCalendarSection = ({
+  calendars,
+  channels,
+  visibleCalendarUrls,
+  onToggleVisibility,
+  onDelete,
+  onReactivate,
+  onRefresh,
+}: SubscriptionCalendarSectionProps) => {
+  const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(true);
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [editState, setEditState] = useState<{
+    channel: SubscriptionChannel;
+    calendarColor?: string;
+  } | null>(null);
+  const [openMenuUrl, setOpenMenuUrl] = useState<string | null>(null);
+
+  const isLimitReached = channels.length >= MAX_SUBSCRIPTIONS_PER_USER;
+
+  const getChannelForCalendar = (calendar: CalDavCalendar) => {
+    const calPath = extractCaldavPath(calendar.url);
+    if (!calPath) return undefined;
+    return channels.find((ch) => calPath === ch.caldav_path);
+  };
+
+  if (calendars.length === 0 && channels.length === 0) {
+    return (
+      <div className="calendar-list__section">
+        <div className="calendar-list__section-header">
+          <button
+            className="calendar-list__toggle-btn"
+            onClick={() => setIsAddModalOpen(true)}
+          >
+            <span className="material-icons" style={{ fontSize: "18px" }}>
+              link
+            </span>
+            <span className="calendar-list__section-title">
+              {t("calendar.list.subscriptions")}
+            </span>
+          </button>
+          <button
+            className="calendar-list__add-btn"
+            onClick={() => setIsAddModalOpen(true)}
+            title={
+              isLimitReached
+                ? t("calendar.subscription.add.limitReached")
+                : t("calendar.subscription.add.title")
+            }
+            disabled={isLimitReached}
+          >
+            <span className="material-icons">add</span>
+          </button>
+        </div>
+
+        <AddSubscriptionModal
+          isOpen={isAddModalOpen}
+          onClose={() => setIsAddModalOpen(false)}
+          onSuccess={onRefresh}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="calendar-list__section">
+      <div className="calendar-list__section-header">
+        <button
+          className="calendar-list__toggle-btn"
+          onClick={() => setIsExpanded(!isExpanded)}
+          aria-expanded={isExpanded}
+        >
+          <span
+            className={`material-icons calendar-list__toggle-icon ${
+              isExpanded ? "calendar-list__toggle-icon--expanded" : ""
+            }`}
+          >
+            expand_more
+          </span>
+          <span className="calendar-list__section-title">
+            {t("calendar.list.subscriptions")}
+          </span>
+        </button>
+        <button
+          className="calendar-list__add-btn"
+          onClick={() => !isLimitReached && setIsAddModalOpen(true)}
+          title={
+            isLimitReached
+              ? t("calendar.subscription.add.limitReached")
+              : t("calendar.subscription.add.title")
+          }
+          disabled={isLimitReached}
+        >
+          <span className="material-icons">add</span>
+        </button>
+      </div>
+
+      {isExpanded && (
+        <div className="calendar-list__items">
+          {calendars.map((calendar) => {
+            const channel = getChannelForCalendar(calendar);
+            return (
+              <div key={calendar.url} className="calendar-list__subscription-item">
+                <CalendarListItem
+                  calendar={calendar}
+                  isVisible={visibleCalendarUrls.has(calendar.url)}
+                  isMenuOpen={openMenuUrl === calendar.url}
+                  onToggleVisibility={onToggleVisibility}
+                  onMenuToggle={(url) =>
+                    setOpenMenuUrl(openMenuUrl === url ? null : url)
+                  }
+                  onEdit={() =>
+                    channel &&
+                    setEditState({
+                      channel,
+                      calendarColor: calendar.color,
+                    })
+                  }
+                  onDelete={() => channel && onDelete(channel)}
+                  onCloseMenu={() => setOpenMenuUrl(null)}
+                />
+                {channel && (
+                  <SubscriptionStatusBadge
+                    channel={channel}
+                    onReactivate={() => onReactivate(channel)}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <AddSubscriptionModal
+        isOpen={isAddModalOpen}
+        onClose={() => setIsAddModalOpen(false)}
+        onSuccess={onRefresh}
+      />
+
+      <EditSubscriptionModal
+        isOpen={editState !== null}
+        channel={editState?.channel ?? null}
+        calendarColor={editState?.calendarColor}
+        onClose={() => setEditState(null)}
+        onSuccess={onRefresh}
+      />
+    </div>
+  );
+};

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/SubscriptionStatusBadge.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/SubscriptionStatusBadge.tsx
@@ -1,0 +1,93 @@
+/**
+ * SubscriptionStatusBadge component.
+ * Shows sync status (ok/error/stopped) for a subscription calendar.
+ */
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@gouvfr-lasuite/cunningham-react";
+
+import type { SubscriptionChannel } from "../../api";
+
+interface SubscriptionStatusBadgeProps {
+  channel: SubscriptionChannel;
+  onReactivate: () => void;
+}
+
+export const SubscriptionStatusBadge = ({
+  channel,
+  onReactivate,
+}: SubscriptionStatusBadgeProps) => {
+  const { t } = useTranslation();
+  const [showError, setShowError] = useState(false);
+
+  if (!channel.is_active) {
+    return (
+      <div className="subscription-status subscription-status--stopped">
+        <span
+          className="subscription-status__icon material-icons"
+          title={t("calendar.subscription.status.stopped")}
+        >
+          block
+        </span>
+        {showError && (
+          <div className="subscription-status__error">
+            <p>{channel.last_sync_error || t("calendar.subscription.status.stoppedDescription")}</p>
+            <Button size="small" onClick={onReactivate}>
+              {t("calendar.subscription.status.reactivate")}
+            </Button>
+          </div>
+        )}
+        <button
+          className="subscription-status__toggle"
+          onClick={() => setShowError(!showError)}
+          title={t("calendar.subscription.status.viewError")}
+        >
+          <span className="material-icons" style={{ fontSize: "14px" }}>
+            {showError ? "expand_less" : "expand_more"}
+          </span>
+        </button>
+      </div>
+    );
+  }
+
+  if (channel.last_sync_status === "ok") {
+    return null;
+  }
+
+  if (channel.last_sync_status === "error") {
+    return (
+      <div className="subscription-status subscription-status--error">
+        <button
+          className="subscription-status__icon material-icons"
+          title={channel.last_sync_error || t("calendar.subscription.status.error")}
+          onClick={() => setShowError(!showError)}
+          style={{ cursor: "pointer", background: "none", border: "none", padding: 0 }}
+          aria-label={t("calendar.subscription.status.viewError")}
+        >
+          warning
+        </button>
+        {showError && (
+          <div className="subscription-status__error">
+            <p>{channel.last_sync_error}</p>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (channel.last_sync_status === "pending") {
+    return (
+      <div className="subscription-status subscription-status--pending">
+        <span
+          className="subscription-status__icon material-icons"
+          title={t("calendar.subscription.status.pending")}
+        >
+          sync
+        </span>
+      </div>
+    );
+  }
+
+  return null;
+};

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/EventModal.scss
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/EventModal.scss
@@ -220,3 +220,35 @@
   gap: 0.5rem;
   flex-wrap: wrap;
 }
+
+// ReadOnlyEventModal
+.readonly-event {
+  &__title {
+    font-size: 1.1rem;
+    font-weight: 600;
+  }
+
+  &__text {
+    color: var(--c--theme--colors--greyscale-600, #5f6368);
+  }
+
+  &__description {
+    margin: 0;
+    white-space: pre-wrap;
+    color: var(--c--theme--colors--greyscale-600, #5f6368);
+  }
+
+  &__attendee-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__attendee-status {
+    color: var(--c--theme--colors--greyscale-500, #80868b);
+    font-size: 0.875rem;
+  }
+}

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/ReadOnlyEventModal.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/ReadOnlyEventModal.tsx
@@ -1,0 +1,195 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Button, Modal, ModalSize } from "@gouvfr-lasuite/cunningham-react";
+
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { useCalendarLocale } from "../../hooks/useCalendarLocale";
+import { SectionRow } from "./event-modal-sections/SectionRow";
+import type { ReadOnlyEventModalProps } from "./types";
+
+export const ReadOnlyEventModal = ({
+  isOpen,
+  event,
+  calendarUrl,
+  calendars,
+  onClose,
+}: ReadOnlyEventModalProps) => {
+  const { t } = useTranslation();
+  const isMobile = useIsMobile();
+  const { intlLocale } = useCalendarLocale();
+
+  const calendarName = useMemo(() => {
+    const cal = calendars.find((c) => c.url === calendarUrl);
+    return cal?.displayName || calendarUrl;
+  }, [calendars, calendarUrl]);
+
+  const formattedDateTime = useMemo(() => {
+    if (!event?.start?.date) return "";
+
+    const start =
+      event.start.date instanceof Date
+        ? event.start.date
+        : new Date(event.start.date);
+
+    const isAllDay = event.start.type === "DATE";
+
+    if (isAllDay) {
+      const dateFormatter = new Intl.DateTimeFormat(intlLocale, {
+        timeZone: "UTC",
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+
+      if (event.end?.date) {
+        const end =
+          event.end.date instanceof Date
+            ? event.end.date
+            : new Date(event.end.date);
+        const endMinusOne = new Date(end.getTime() - 86400000);
+        if (endMinusOne.getTime() <= start.getTime()) {
+          return dateFormatter.format(start);
+        }
+        return `${dateFormatter.format(start)} — ${dateFormatter.format(endMinusOne)}`;
+      }
+      return dateFormatter.format(start);
+    }
+
+    // Dates from the adapter use "fake UTC" — UTC components hold the
+    // local-timezone time. We must format with timeZone: "UTC" so the
+    // formatter reads those UTC components as-is.
+    const dateTimeFormatter = new Intl.DateTimeFormat(intlLocale, {
+      timeZone: "UTC",
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+
+    if (event.end?.date) {
+      const end =
+        event.end.date instanceof Date
+          ? event.end.date
+          : new Date(event.end.date);
+
+      const sameDay =
+        start.getUTCFullYear() === end.getUTCFullYear() &&
+        start.getUTCMonth() === end.getUTCMonth() &&
+        start.getUTCDate() === end.getUTCDate();
+
+      if (sameDay) {
+        const timeFormatter = new Intl.DateTimeFormat(intlLocale, {
+          timeZone: "UTC",
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+        return `${dateTimeFormatter.format(start)} — ${timeFormatter.format(end)}`;
+      }
+      return `${dateTimeFormatter.format(start)} — ${dateTimeFormatter.format(end)}`;
+    }
+
+    return dateTimeFormatter.format(start);
+  }, [event, intlLocale]);
+
+  const organizer = event?.organizer;
+  const attendees = event?.attendees;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size={isMobile ? ModalSize.FULL : ModalSize.MEDIUM}
+      title={t("calendar.event.viewTitle")}
+      rightActions={
+        <Button color="neutral" onClick={onClose}>
+          {t("common.close")}
+        </Button>
+      }
+    >
+      <div className="event-modal__content">
+        {event?.summary && (
+          <SectionRow icon="edit" label={t("calendar.event.title")} alwaysOpen>
+            <span className="readonly-event__title">{event.summary}</span>
+          </SectionRow>
+        )}
+
+        <SectionRow
+          icon="event"
+          label={t("calendar.event.calendar")}
+          alwaysOpen
+        >
+          <span className="readonly-event__text">{calendarName}</span>
+        </SectionRow>
+
+        {formattedDateTime && (
+          <SectionRow
+            icon="schedule"
+            label={t("calendar.event.date")}
+            alwaysOpen
+          >
+            <span className="readonly-event__text">{formattedDateTime}</span>
+          </SectionRow>
+        )}
+
+        {event?.location && (
+          <SectionRow
+            icon="place"
+            label={t("calendar.event.location")}
+            alwaysOpen
+          >
+            <span className="readonly-event__text">{event.location}</span>
+          </SectionRow>
+        )}
+
+        {event?.description && (
+          <SectionRow
+            icon="notes"
+            label={t("calendar.event.description")}
+            alwaysOpen
+            iconAlign="flex-start"
+          >
+            <p className="readonly-event__description">{event.description}</p>
+          </SectionRow>
+        )}
+
+        {organizer && (
+          <SectionRow
+            icon="person"
+            label={t("calendar.event.organizer")}
+            alwaysOpen
+          >
+            <span className="readonly-event__text">
+              {organizer.name || organizer.email}
+            </span>
+          </SectionRow>
+        )}
+
+        {attendees && attendees.length > 0 && (
+          <SectionRow
+            icon="group"
+            label={t("calendar.event.attendees")}
+            alwaysOpen
+            iconAlign="flex-start"
+          >
+            <ul className="readonly-event__attendee-list">
+              {attendees.map((att, index) => (
+                <li key={att.email || att.name || index} className="readonly-event__attendee">
+                  <span>{att.name || att.email}</span>
+                  {att.partstat && att.partstat !== "NEEDS-ACTION" && (
+                    <span className="readonly-event__attendee-status">
+                      {" "}
+                      ({att.partstat.toLowerCase()})
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </SectionRow>
+        )}
+      </div>
+    </Modal>
+  );
+};

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/Scheduler.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/Scheduler.tsx
@@ -403,20 +403,35 @@ export const Scheduler = ({ defaultCalendarUrl }: SchedulerProps) => {
           onClose={handleModalClose}
         />
       ) : (
-        <EventModal
-          isOpen={modalState.isOpen}
-          mode={modalState.mode}
-          event={modalState.event}
-          calendarUrl={modalState.calendarUrl}
-          calendars={davCalendars.filter(
+        (() => {
+          const writableCalendars = davCalendars.filter(
             (cal) => !subscriptionCalendarUrls.has(cal.url),
-          )}
-          adapter={adapter}
-          onSave={handleModalSave}
-          onDelete={modalState.mode === "edit" ? handleModalDelete : undefined}
-          onRespondToInvitation={handleRespondToInvitation}
-          onClose={handleModalClose}
-        />
+          );
+          // If the modal was opened while a subscription calendar was
+          // selected, fall back to the first writable calendar so the
+          // form never shows a selection that's absent from the options.
+          const sanitizedCalendarUrl = subscriptionCalendarUrls.has(
+            modalState.calendarUrl,
+          )
+            ? (writableCalendars[0]?.url ?? "")
+            : modalState.calendarUrl;
+          return (
+            <EventModal
+              isOpen={modalState.isOpen}
+              mode={modalState.mode}
+              event={modalState.event}
+              calendarUrl={sanitizedCalendarUrl}
+              calendars={writableCalendars}
+              adapter={adapter}
+              onSave={handleModalSave}
+              onDelete={
+                modalState.mode === "edit" ? handleModalDelete : undefined
+              }
+              onRespondToInvitation={handleRespondToInvitation}
+              onClose={handleModalClose}
+            />
+          );
+        })()
       )}
 
       <RecurringEditModal

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/Scheduler.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/Scheduler.tsx
@@ -144,6 +144,7 @@ export const Scheduler = ({ defaultCalendarUrl }: SchedulerProps) => {
     calendarUrl,
     modalState,
     setModalState,
+    readOnlyCalendarUrls: subscriptionCalendarUrls,
   });
 
   // Callback to update toolbar state when calendar dates/view changes
@@ -215,12 +216,16 @@ export const Scheduler = ({ defaultCalendarUrl }: SchedulerProps) => {
     }
   }, [isConnected]);
 
-  // Update eventFilter when visible calendars change
+  // Update eventFilter when visible calendars change.
+  // Also refetch when subscriptionCalendarUrls changes so already-rendered
+  // events get their `editable` flag recomputed once the subscription
+  // list arrives — otherwise drag/resize stays enabled for subscription
+  // events until an unrelated refetch happens.
   useEffect(() => {
     if (calendarRef.current) {
       calendarRef.current.refetchEvents();
     }
-  }, [visibleCalendarUrls, davCalendars]);
+  }, [visibleCalendarUrls, davCalendars, subscriptionCalendarUrls]);
 
   const handleViewChange = useCallback(
     (view: string) => {

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/Scheduler.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/Scheduler.tsx
@@ -28,6 +28,7 @@ import type { EventCalendarEvent } from "../../services/dav/types/event-calendar
 import { useIsMobile } from "@/hooks/useIsMobile";
 
 import { EventModal } from "./EventModal";
+import { ReadOnlyEventModal } from "./ReadOnlyEventModal";
 import { RecurringEditModal } from "./RecurringEditModal";
 import { SchedulerToolbar } from "./SchedulerToolbar";
 import type { SchedulerProps, EventModalState, MobileListEvent } from "./types";
@@ -76,6 +77,7 @@ export const Scheduler = ({ defaultCalendarUrl }: SchedulerProps) => {
     adapter,
     davCalendars,
     visibleCalendarUrls,
+    subscriptionCalendarUrls,
     isConnected,
     calendarRef: contextCalendarRef,
     currentDate,
@@ -87,6 +89,8 @@ export const Scheduler = ({ defaultCalendarUrl }: SchedulerProps) => {
 
   const containerRef = useRef<HTMLDivElement>(null);
   const calendarRef = contextCalendarRef;
+  const readOnlyCalendarUrlsRef = useRef(subscriptionCalendarUrls);
+  readOnlyCalendarUrlsRef.current = subscriptionCalendarUrls;
   const [calendarUrl, setCalendarUrl] = useState(defaultCalendarUrl || "");
 
   // Toolbar state
@@ -189,6 +193,7 @@ export const Scheduler = ({ defaultCalendarUrl }: SchedulerProps) => {
     adapter,
     visibleCalendarUrlsRef,
     davCalendarsRef,
+    readOnlyCalendarUrlsRef,
     initialView: isMobile ? "timeGridDay" : "timeGridWeek",
     setCurrentDate: handleDatesSet,
     handleEventClick: handleEventClick as (info: unknown) => void,
@@ -319,16 +324,20 @@ export const Scheduler = ({ defaultCalendarUrl }: SchedulerProps) => {
         defaultTimezone: extProps?.timezone || BROWSER_TIMEZONE,
       });
 
+      const isReadOnly = subscriptionCalendarUrls.has(
+        extProps?.calendarUrl || "",
+      );
+
       setModalState({
         isOpen: true,
-        mode: "edit",
+        mode: isReadOnly ? "view" : "edit",
         event: icsEvent,
         calendarUrl: extProps?.calendarUrl || calendarUrl,
         eventUrl: extProps?.eventUrl,
         etag: extProps?.etag,
       });
     },
-    [adapter, calendarUrl, calendarRef],
+    [adapter, calendarUrl, calendarRef, subscriptionCalendarUrls],
   );
 
   return (
@@ -380,18 +389,30 @@ export const Scheduler = ({ defaultCalendarUrl }: SchedulerProps) => {
 
       {isMobile && <FloatingActionButton onClick={handleFabClick} />}
 
-      <EventModal
-        isOpen={modalState.isOpen}
-        mode={modalState.mode}
-        event={modalState.event}
-        calendarUrl={modalState.calendarUrl}
-        calendars={davCalendars}
-        adapter={adapter}
-        onSave={handleModalSave}
-        onDelete={modalState.mode === "edit" ? handleModalDelete : undefined}
-        onRespondToInvitation={handleRespondToInvitation}
-        onClose={handleModalClose}
-      />
+      {modalState.mode === "view" ? (
+        <ReadOnlyEventModal
+          isOpen={modalState.isOpen}
+          event={modalState.event}
+          calendarUrl={modalState.calendarUrl}
+          calendars={davCalendars}
+          onClose={handleModalClose}
+        />
+      ) : (
+        <EventModal
+          isOpen={modalState.isOpen}
+          mode={modalState.mode}
+          event={modalState.event}
+          calendarUrl={modalState.calendarUrl}
+          calendars={davCalendars.filter(
+            (cal) => !subscriptionCalendarUrls.has(cal.url),
+          )}
+          adapter={adapter}
+          onSave={handleModalSave}
+          onDelete={modalState.mode === "edit" ? handleModalDelete : undefined}
+          onRespondToInvitation={handleRespondToInvitation}
+          onClose={handleModalClose}
+        />
+      )}
 
       <RecurringEditModal
         isOpen={!!pendingRecurringAction}

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/hooks/useSchedulerHandlers.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/hooks/useSchedulerHandlers.ts
@@ -108,6 +108,12 @@ export const useSchedulerHandlers = ({
    */
   const handleEventDrop = useCallback(
     async (info: EventCalendarEventDropInfo) => {
+      // Block writes on read-only (subscription) events
+      if (info.event.editable === false) {
+        info.revert();
+        return;
+      }
+
       const extProps = info.event.extendedProps as CalDavExtendedProps;
 
       if (!extProps?.eventUrl) {
@@ -160,6 +166,12 @@ export const useSchedulerHandlers = ({
    */
   const handleEventResize = useCallback(
     async (info: EventCalendarEventResizeInfo) => {
+      // Block writes on read-only (subscription) events
+      if (info.event.editable === false) {
+        info.revert();
+        return;
+      }
+
       const extProps = info.event.extendedProps as CalDavExtendedProps;
 
       if (!extProps?.eventUrl) {
@@ -216,10 +228,23 @@ export const useSchedulerHandlers = ({
     (info: EventCalendarEventClickInfo) => {
       const extProps = info.event.extendedProps as CalDavExtendedProps;
 
-      // Convert EventCalendar event back to IcsEvent for editing
+      // Convert EventCalendar event back to IcsEvent
       const icsEvent = adapter.toIcsEvent(info.event as EventCalendarEvent, {
         defaultTimezone: extProps?.timezone || BROWSER_TIMEZONE,
       });
+
+      // Read-only (subscription) events: open in view mode
+      if (info.event.editable === false) {
+        setModalState({
+          isOpen: true,
+          mode: "view",
+          event: icsEvent,
+          calendarUrl: extProps?.calendarUrl || calendarUrl,
+          eventUrl: extProps?.eventUrl,
+          etag: extProps?.etag,
+        });
+        return;
+      }
 
       setModalState({
         isOpen: true,

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/hooks/useSchedulerHandlers.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/hooks/useSchedulerHandlers.ts
@@ -79,6 +79,7 @@ interface UseSchedulerHandlersProps {
   calendarUrl: string;
   modalState: EventModalState;
   setModalState: React.Dispatch<React.SetStateAction<EventModalState>>;
+  readOnlyCalendarUrls: Set<string>;
 }
 
 /**
@@ -97,6 +98,7 @@ export const useSchedulerHandlers = ({
   calendarUrl,
   modalState,
   setModalState,
+  readOnlyCalendarUrls,
 }: UseSchedulerHandlersProps) => {
   const { user } = useAuth();
   const [pendingRecurringAction, setPendingRecurringAction] =
@@ -108,8 +110,18 @@ export const useSchedulerHandlers = ({
    */
   const handleEventDrop = useCallback(
     async (info: EventCalendarEventDropInfo) => {
-      // Block writes on read-only (subscription) events
-      if (info.event.editable === false) {
+      const targetResourceId =
+        typeof info.newResource?.id === "string"
+          ? info.newResource.id
+          : undefined;
+
+      // Block writes on read-only (subscription) events, and also reject
+      // drops whose destination resource is a subscription calendar — a
+      // writable event must not land in a read-only feed.
+      if (
+        info.event.editable === false ||
+        (targetResourceId && readOnlyCalendarUrls.has(targetResourceId))
+      ) {
         info.revert();
         return;
       }
@@ -157,7 +169,7 @@ export const useSchedulerHandlers = ({
         info.revert();
       }
     },
-    [adapter, caldavService, calendarRef]
+    [adapter, caldavService, calendarRef, readOnlyCalendarUrls]
   );
 
   /**

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/hooks/useSchedulerInit.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/hooks/useSchedulerInit.ts
@@ -33,6 +33,7 @@ interface UseSchedulerInitProps {
   adapter: EventCalendarAdapter;
   visibleCalendarUrlsRef: MutableRefObject<Set<string>>;
   davCalendarsRef: MutableRefObject<CalDavCalendar[]>;
+  readOnlyCalendarUrlsRef?: MutableRefObject<Set<string>>;
   initialView?: string;
   setCurrentDate: (info: { start: Date; end: Date }) => void;
   handleEventClick: (info: unknown) => void;
@@ -58,6 +59,7 @@ export const useSchedulerInit = ({
   adapter,
   visibleCalendarUrlsRef,
   davCalendarsRef,
+  readOnlyCalendarUrlsRef,
   initialView = "timeGridWeek",
   setCurrentDate,
   handleEventClick,
@@ -246,7 +248,10 @@ export const useSchedulerInit = ({
 
                   return adapter.toEventCalendarEvents(
                     enrichedData as typeof result.data,
-                    { calendarColors }
+                    {
+                      calendarColors,
+                      readOnlyCalendarUrls: readOnlyCalendarUrlsRef?.current,
+                    }
                   );
                 });
 

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/types.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/types.ts
@@ -52,6 +52,17 @@ export interface EventModalProps {
 }
 
 /**
+ * Props for the ReadOnlyEventModal component.
+ */
+export interface ReadOnlyEventModalProps {
+  isOpen: boolean;
+  event: Partial<IcsEvent> | null;
+  calendarUrl: string;
+  calendars: CalDavCalendar[];
+  onClose: () => void;
+}
+
+/**
  * Props for the DeleteEventModal component.
  */
 export interface DeleteEventModalProps {
@@ -82,7 +93,7 @@ export interface SchedulerProps {
  */
 export interface EventModalState {
   isOpen: boolean;
-  mode: "create" | "edit";
+  mode: "create" | "edit" | "view";
   event: Partial<IcsEvent> | null;
   calendarUrl: string;
   eventUrl?: string;

--- a/src/frontend/apps/calendars/src/features/calendar/config.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/config.ts
@@ -3,10 +3,22 @@
  * Values can be overridden via NEXT_PUBLIC_ environment variables.
  */
 
+const parsePositiveInt = (
+  value: string | undefined,
+  fallback: number,
+): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+};
+
 /** Polling interval for subscription status refresh (milliseconds). Default: 60s. */
-export const SYNC_POLL_INTERVAL =
-  Number(process.env.NEXT_PUBLIC_SYNC_POLL_INTERVAL) || 60_000;
+export const SYNC_POLL_INTERVAL = parsePositiveInt(
+  process.env.NEXT_PUBLIC_SYNC_POLL_INTERVAL,
+  60_000,
+);
 
 /** Maximum number of subscription channels per user. */
-export const MAX_SUBSCRIPTIONS_PER_USER =
-  Number(process.env.NEXT_PUBLIC_MAX_SUBSCRIPTIONS_PER_USER) || 20;
+export const MAX_SUBSCRIPTIONS_PER_USER = parsePositiveInt(
+  process.env.NEXT_PUBLIC_MAX_SUBSCRIPTIONS_PER_USER,
+  20,
+);

--- a/src/frontend/apps/calendars/src/features/calendar/config.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/config.ts
@@ -1,0 +1,12 @@
+/**
+ * Calendar feature configuration.
+ * Values can be overridden via NEXT_PUBLIC_ environment variables.
+ */
+
+/** Polling interval for subscription status refresh (milliseconds). Default: 60s. */
+export const SYNC_POLL_INTERVAL =
+  Number(process.env.NEXT_PUBLIC_SYNC_POLL_INTERVAL) || 60_000;
+
+/** Maximum number of subscription channels per user. */
+export const MAX_SUBSCRIPTIONS_PER_USER =
+  Number(process.env.NEXT_PUBLIC_MAX_SUBSCRIPTIONS_PER_USER) || 20;

--- a/src/frontend/apps/calendars/src/features/calendar/contexts/CalendarContext.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/contexts/CalendarContext.tsx
@@ -121,25 +121,40 @@ export const CalendarContextProvider = ({
   const [currentDate, setCurrentDate] = useState<Date>(new Date());
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
 
-  // Track subscription calendar URLs for read-only enforcement
+  // Track subscription calendar URLs for read-only enforcement.
+  // Must mirror the backend's normalize_caldav_path in
+  // core/services/caldav_service.py: strip any prefix before
+  // "/calendars/" so paths returned by SabreDAV (e.g.
+  // "/api/v1.0/caldav/calendars/users/…") compare equal to channel
+  // caldav_path values stored as "/calendars/users/…".
   const { data: subscriptionChannelsData } = useSubscriptionChannels();
   const subscriptionCalendarUrls = useMemo(() => {
     if (!subscriptionChannelsData?.length || !davCalendars.length)
       return new Set<string>();
+
+    const normalizeCaldavPath = (value: string): string => {
+      let pathname: string;
+      try {
+        pathname = value.startsWith("/") ? value : new URL(value).pathname;
+      } catch {
+        return "";
+      }
+      const calendarsIdx = pathname.indexOf("/calendars/");
+      const normalized =
+        calendarsIdx >= 0 ? pathname.slice(calendarsIdx) : pathname;
+      return normalized.replace(/\/$/, "");
+    };
+
     const subscriptionPaths = new Set(
-      subscriptionChannelsData.map((ch) => ch.caldav_path.replace(/\/$/, "")),
+      subscriptionChannelsData
+        .map((ch) => normalizeCaldavPath(ch.caldav_path))
+        .filter(Boolean),
     );
     return new Set(
       davCalendars
         .filter((cal) => {
-          // Extract path from full URL and compare exactly
-          try {
-            const calPath = new URL(cal.url).pathname.replace(/\/$/, "");
-            const normalizedPath = calPath.replace(/^\/caldav/, "");
-            return subscriptionPaths.has(normalizedPath);
-          } catch {
-            return false;
-          }
+          const normalizedPath = normalizeCaldavPath(cal.url);
+          return !!normalizedPath && subscriptionPaths.has(normalizedPath);
         })
         .map((cal) => cal.url),
     );

--- a/src/frontend/apps/calendars/src/features/calendar/contexts/CalendarContext.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/contexts/CalendarContext.tsx
@@ -22,6 +22,8 @@ import {
   addToast,
   ToasterItem,
 } from "@/features/ui/components/toaster/Toaster";
+import { useSubscriptionChannels } from "../hooks/useCalendars";
+import { SYNC_POLL_INTERVAL } from "../config";
 
 const HIDDEN_CALENDARS_KEY = "calendar-hidden-urls";
 
@@ -55,6 +57,7 @@ export interface CalendarContextType {
   davCalendars: CalDavCalendar[];
   ownedCalendars: CalDavCalendar[];
   sharedCalendars: CalDavCalendar[];
+  subscriptionCalendarUrls: Set<string>;
   visibleCalendarUrls: Set<string>;
   isLoading: boolean;
   isConnected: boolean;
@@ -117,6 +120,30 @@ export const CalendarContextProvider = ({
   const [isConnected, setIsConnected] = useState(false);
   const [currentDate, setCurrentDate] = useState<Date>(new Date());
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+
+  // Track subscription calendar URLs for read-only enforcement
+  const { data: subscriptionChannelsData } = useSubscriptionChannels();
+  const subscriptionCalendarUrls = useMemo(() => {
+    if (!subscriptionChannelsData?.length || !davCalendars.length)
+      return new Set<string>();
+    const subscriptionPaths = new Set(
+      subscriptionChannelsData.map((ch) => ch.caldav_path.replace(/\/$/, "")),
+    );
+    return new Set(
+      davCalendars
+        .filter((cal) => {
+          // Extract path from full URL and compare exactly
+          try {
+            const calPath = new URL(cal.url).pathname.replace(/\/$/, "");
+            const normalizedPath = calPath.replace(/^\/caldav/, "");
+            return subscriptionPaths.has(normalizedPath);
+          } catch {
+            return false;
+          }
+        })
+        .map((cal) => cal.url),
+    );
+  }, [subscriptionChannelsData, davCalendars]);
 
   const { ownedCalendars, sharedCalendars } = useMemo(() => {
     const homeUrl = caldavService.getAccount()?.homeUrl;
@@ -309,7 +336,18 @@ export const CalendarContextProvider = ({
     }
   }, []);
 
-  // Note: refetchEvents is called in Scheduler component after updating the ref
+  // Periodic refresh: poll calendars and events every 5 minutes
+  // to pick up subscription sync changes
+  useEffect(() => {
+    if (!isConnected) return;
+    const interval = setInterval(() => {
+      refreshCalendars();
+      if (calendarRef.current) {
+        calendarRef.current.refetchEvents();
+      }
+    }, SYNC_POLL_INTERVAL);
+    return () => clearInterval(interval);
+  }, [isConnected, refreshCalendars, calendarRef]);
 
   // Connect to CalDAV server on mount
   useEffect(() => {
@@ -377,6 +415,7 @@ export const CalendarContextProvider = ({
     davCalendars,
     ownedCalendars,
     sharedCalendars,
+    subscriptionCalendarUrls,
     visibleCalendarUrls,
     isLoading,
     isConnected,

--- a/src/frontend/apps/calendars/src/features/calendar/contexts/CalendarContext.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/contexts/CalendarContext.tsx
@@ -351,18 +351,17 @@ export const CalendarContextProvider = ({
     }
   }, []);
 
-  // Periodic refresh: poll calendars and events every 5 minutes
-  // to pick up subscription sync changes
+  // Periodic refresh: poll calendars every 5 minutes to pick up
+  // subscription sync changes. Scheduler.tsx already refetches events
+  // when davCalendars changes, so we don't call refetchEvents() here
+  // — doing both would double CalDAV traffic on every tick.
   useEffect(() => {
     if (!isConnected) return;
     const interval = setInterval(() => {
       refreshCalendars();
-      if (calendarRef.current) {
-        calendarRef.current.refetchEvents();
-      }
     }, SYNC_POLL_INTERVAL);
     return () => clearInterval(interval);
-  }, [isConnected, refreshCalendars, calendarRef]);
+  }, [isConnected, refreshCalendars]);
 
   // Connect to CalDAV server on mount
   useEffect(() => {

--- a/src/frontend/apps/calendars/src/features/calendar/hooks/useCalendars.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/hooks/useCalendars.ts
@@ -14,7 +14,14 @@ import {
   startImportTask,
   pollImportTask,
   ImportEventsResult,
+  SubscriptionChannel,
+  getSubscriptionChannels,
+  createSubscriptionChannel,
+  updateSubscriptionChannel,
+  deleteSubscriptionChannel,
+  reactivateSubscriptionChannel,
 } from "../api";
+import { SYNC_POLL_INTERVAL } from "../config";
 
 /**
  * Result type for useICalFeedChannel hook.
@@ -103,6 +110,91 @@ export const useImportEvents = () => {
     mutationFn: async ({ caldavPath, file }) => {
       const taskId = await startImportTask(caldavPath, file);
       return pollImportTask(taskId);
+    },
+  });
+};
+
+// ============================================================================
+// Subscription Channel Hooks
+// ============================================================================
+
+/**
+ * Hook to get all subscription channels.
+ */
+export const useSubscriptionChannels = () => {
+  return useQuery<SubscriptionChannel[]>({
+    queryKey: ["subscription-channels"],
+    queryFn: getSubscriptionChannels,
+    refetchInterval: SYNC_POLL_INTERVAL,
+  });
+};
+
+/**
+ * Hook to create a subscription channel.
+ */
+export const useCreateSubscriptionChannel = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: createSubscriptionChannel,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["subscription-channels"],
+      });
+    },
+  });
+};
+
+/**
+ * Hook to update a subscription channel.
+ */
+export const useUpdateSubscriptionChannel = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      channelId,
+      params,
+    }: {
+      channelId: string;
+      params: { name?: string; sourceUrl?: string; color?: string };
+    }) => updateSubscriptionChannel(channelId, params),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["subscription-channels"],
+      });
+    },
+  });
+};
+
+/**
+ * Hook to delete a subscription channel.
+ */
+export const useDeleteSubscriptionChannel = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteSubscriptionChannel,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["subscription-channels"],
+      });
+    },
+  });
+};
+
+/**
+ * Hook to reactivate a stopped subscription channel.
+ */
+export const useReactivateSubscriptionChannel = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: reactivateSubscriptionChannel,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["subscription-channels"],
+      });
     },
   });
 };

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/EventCalendarAdapter.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/EventCalendarAdapter.ts
@@ -327,6 +327,8 @@ export class EventCalendarAdapter {
       Object.assign(extendedProps, opts.extendedPropsExtractor(icsEvent))
     }
 
+    const isReadOnly = !!(opts.readOnlyCalendarUrls?.has(calendarUrl))
+
     return {
       id,
       start: allDay ? this.dateToDateOnlyString(start) : this.dateToLocalISOString(start),
@@ -337,7 +339,9 @@ export class EventCalendarAdapter {
       title: icsEvent.summary ?? '',
       backgroundColor,
       textColor,
-      editable: true,
+      editable: !isReadOnly,
+      startEditable: isReadOnly ? false : undefined,
+      durationEditable: isReadOnly ? false : undefined,
       extendedProps,
     }
   }

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/types/event-calendar.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/types/event-calendar.ts
@@ -420,6 +420,8 @@ export type CalDavToEventCalendarOptions = {
   extendedPropsExtractor?: (event: unknown) => Record<string, unknown>
   /** Map calendar URLs to colors */
   calendarColors?: Map<string, string>
+  /** Set of calendar URLs that are read-only (subscription calendars) */
+  readOnlyCalendarUrls?: Set<string>
 }
 
 export type EventCalendarToCalDavOptions = {

--- a/src/frontend/apps/calendars/src/features/i18n/translations.json
+++ b/src/frontend/apps/calendars/src/features/i18n/translations.json
@@ -147,6 +147,7 @@
         "event": {
           "createTitle": "Create event",
           "editTitle": "Edit event",
+          "viewTitle": "Event details",
           "calendar": "Calendar",
           "title": "Title",
           "titlePlaceholder": "Event title",
@@ -225,6 +226,7 @@
           "defaultCalendarName": "My calendar",
           "myCalendars": "My calendars",
           "sharedCalendars": "Shared calendars",
+          "subscriptions": "Subscriptions",
           "shared": "(shared)",
           "mailboxCalendar": "Mailbox calendar: {{email}}",
           "unnamed": "Unnamed calendar",
@@ -265,7 +267,30 @@
           "error": "Failed to generate subscription URL. Please try again.",
           "errorPermission": "You don't have permission to access this calendar.",
           "errorNetwork": "Network error. Please check your connection and try again.",
-          "errorServer": "Server error. Please try again later."
+          "errorServer": "Server error. Please try again later.",
+          "add": {
+            "title": "Add subscription",
+            "description": "Paste the URL of an external calendar (ICS) to subscribe to it. Events will sync automatically.",
+            "urlLabel": "Calendar URL",
+            "nameLabel": "Display name",
+            "namePlaceholder": "e.g. Public Holidays",
+            "submit": "Subscribe",
+            "error": "Failed to subscribe. Please verify the URL and try again.",
+            "limitReached": "Maximum number of subscriptions reached"
+          },
+          "edit": {
+            "title": "Edit subscription",
+            "save": "Save",
+            "error": "Failed to update. Please verify the URL and try again."
+          },
+          "status": {
+            "pending": "Syncing...",
+            "error": "Sync error",
+            "stopped": "Sync stopped",
+            "stoppedDescription": "Synchronization stopped after multiple failures. Please verify the URL is still valid.",
+            "reactivate": "Reactivate",
+            "viewError": "View error"
+          }
         },
         "leftPanel": {
           "newEvent": "New event"
@@ -1029,6 +1054,7 @@
         "event": {
           "createTitle": "Créer un événement",
           "editTitle": "Modifier l'événement",
+          "viewTitle": "Détails de l'événement",
           "calendar": "Calendrier",
           "title": "Titre",
           "titlePlaceholder": "Titre de l'événement",
@@ -1107,6 +1133,7 @@
           "defaultCalendarName": "Mon calendrier",
           "myCalendars": "Mes calendriers",
           "sharedCalendars": "Calendriers partagés",
+          "subscriptions": "Abonnements",
           "shared": "(partagé)",
           "unnamed": "Calendrier sans nom",
           "mailboxCalendar": "Boîte partagée : {{email}}",
@@ -1147,7 +1174,30 @@
           "error": "Échec de la génération de l'URL d'abonnement. Veuillez réessayer.",
           "errorPermission": "Vous n'avez pas la permission d'accéder à ce calendrier.",
           "errorNetwork": "Erreur réseau. Veuillez vérifier votre connexion et réessayer.",
-          "errorServer": "Erreur serveur. Veuillez réessayer plus tard."
+          "errorServer": "Erreur serveur. Veuillez réessayer plus tard.",
+          "add": {
+            "title": "Ajouter un abonnement",
+            "description": "Collez l'URL d'un calendrier externe (ICS) pour vous y abonner. Les événements se synchroniseront automatiquement.",
+            "urlLabel": "URL du calendrier",
+            "nameLabel": "Nom d'affichage",
+            "namePlaceholder": "ex. Jours fériés",
+            "submit": "S'abonner",
+            "error": "Échec de l'abonnement. Veuillez vérifier l'URL et réessayer.",
+            "limitReached": "Nombre maximum d'abonnements atteint"
+          },
+          "edit": {
+            "title": "Modifier l'abonnement",
+            "save": "Enregistrer",
+            "error": "Échec de la mise à jour. Veuillez vérifier l'URL et réessayer."
+          },
+          "status": {
+            "pending": "Synchronisation...",
+            "error": "Erreur de synchronisation",
+            "stopped": "Synchronisation arrêtée",
+            "stoppedDescription": "La synchronisation s'est arrêtée après plusieurs échecs. Veuillez vérifier que l'URL est toujours valide.",
+            "reactivate": "Réactiver",
+            "viewError": "Voir l'erreur"
+          }
         },
         "leftPanel": {
           "newEvent": "Nouvel événement"
@@ -1653,6 +1703,7 @@
         "event": {
           "createTitle": "Evenement aanmaken",
           "editTitle": "Evenement bewerken",
+          "viewTitle": "Evenementdetails",
           "calendar": "Kalender",
           "title": "Titel",
           "titlePlaceholder": "Evenement titel",
@@ -1731,6 +1782,7 @@
           "defaultCalendarName": "Mijn kalender",
           "myCalendars": "Mijn kalenders",
           "sharedCalendars": "Gedeelde kalenders",
+          "subscriptions": "Abonnementen",
           "shared": "(gedeeld)",
           "unnamed": "Naamloze kalender",
           "mailboxCalendar": "Gedeelde mailbox: {{email}}",
@@ -1771,7 +1823,30 @@
           "error": "Genereren van abonnements-URL mislukt. Probeer het opnieuw.",
           "errorPermission": "U heeft geen toegang tot deze kalender.",
           "errorNetwork": "Netwerkfout. Controleer uw verbinding en probeer het opnieuw.",
-          "errorServer": "Serverfout. Probeer het later opnieuw."
+          "errorServer": "Serverfout. Probeer het later opnieuw.",
+          "add": {
+            "title": "Abonnement toevoegen",
+            "description": "Plak de URL van een externe kalender (ICS) om u erop te abonneren. Evenementen worden automatisch gesynchroniseerd.",
+            "urlLabel": "Kalender-URL",
+            "nameLabel": "Weergavenaam",
+            "namePlaceholder": "bijv. Feestdagen",
+            "submit": "Abonneren",
+            "error": "Abonneren mislukt. Controleer de URL en probeer het opnieuw.",
+            "limitReached": "Maximaal aantal abonnementen bereikt"
+          },
+          "edit": {
+            "title": "Abonnement bewerken",
+            "save": "Opslaan",
+            "error": "Bijwerken mislukt. Controleer de URL en probeer het opnieuw."
+          },
+          "status": {
+            "pending": "Synchroniseren...",
+            "error": "Synchronisatiefout",
+            "stopped": "Synchronisatie gestopt",
+            "stoppedDescription": "Synchronisatie is gestopt na meerdere fouten. Controleer of de URL nog geldig is.",
+            "reactivate": "Opnieuw activeren",
+            "viewError": "Fout bekijken"
+          }
         },
         "leftPanel": {
           "newEvent": "Nieuw evenement"


### PR DESCRIPTION
## Purpose

Allow users to subscribe to external ICS calendar feeds
(e.g. public holidays, shared team calendars) and have
events automatically synced into their La Suite calendar.

Subscribed calendars appear alongside owned calendars in
the sidebar but are read-only: events cannot be edited,
moved, or deleted by the user.

## What was done

### Backend

- **URL validation service** with SSRF protection:
  hostname resolution checks, private IP blocking,
  safe redirect handling, conditional requests
  (ETag / If-Modified-Since), and response size limits.
- **Diff-based sync service** that compares UIDs from
  the external ICS with existing SabreDAV events, then
  creates, updates, or deletes as needed. Includes
  Redis-based locking, auto-stop after 3 consecutive
  errors, infinite RRULE capping, and volatile property
  filtering to avoid unnecessary updates.
- **Dramatiq tasks + management command scheduler** for
  periodic sync with staggered dispatch per channel.
- **Channel CRUD endpoints**: create, update (name/URL/
  color), delete, reactivate. Per-user limit (20),
  immediate sync on creation, event purge on URL change,
  SabreDAV calendar cleanup on deletion.
- **CalDAV proxy read-only enforcement**: write methods
  (PUT, DELETE, MOVE, PROPPATCH) return 403 for
  subscription calendars, even when the subscription
  is stopped.

### Infrastructure

- New `subscription-scheduler` Docker service running
  the management command for periodic syncs.
- Makefile targets updated (`start`, `start-back`).
- New `reset-db-full` target for full DB recreation.

### Frontend

- **API client + React Query hooks** for subscription
  channel CRUD (create, update, delete, reactivate,
  list) with periodic polling.
- **Subscription management UI**: add/edit modals with
  URL validation feedback, status badge (syncing /
  error / stopped), dedicated sidebar section,
  reusable ColorPicker component.
- **Read-only mode**: subscription events are marked
  non-editable in FullCalendar, a read-only modal
  opens on click, drag-and-drop and resize are blocked,
  subscription calendars are filtered from the event
  creation calendar picker.
- **Translations** for EN, FR, and NL.

### Tests

- URL validation: scheme checks, SSRF, redirects,
  content validation, conditional requests.
- Sync service: create/update/delete, diff detection,
  RRULE capping, error handling, locking.
- Tasks: fan-out dispatch, interval filtering.
- CalDAV proxy: write blocking on subscription paths.
- API: per-user limit, URL change purge, CRUD flow.

## Test plan

- [ ] Create a subscription with a valid ICS URL
- [ ] Verify events appear in the calendar
- [ ] Verify events are read-only (no edit, no drag)
- [ ] Change the subscription URL and verify purge+resync
- [ ] Trigger 3+ consecutive errors and verify auto-stop
- [ ] Reactivate a stopped subscription
- [ ] Delete a subscription and verify cleanup
- [ ] Verify per-user limit (20 max)
- [ ] Verify SSRF protection (private IPs rejected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add external calendar subscriptions: create/edit/delete/reactivate, background scheduler syncing, subscription UI section, read-only event view, status badges, color picker, and subscription modals.

* **Security / Limits**
  * HTTPS-only subscription fetching with SSRF/hostname validation and per-user subscription limit (default 20).

* **Documentation**
  * Added a French manual test plan for external subscriptions.

* **Tests**
  * New unit/integration tests covering URL validation, syncing, proxy read-only enforcement, tasks, and API flows.

* **Chores**
  * Added scheduler service and DB reset/start targets to local dev tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->