### PR TITLE
✨(callbacks) simplify callback URL logic

### DIFF
--- a/.github/workflows/calendars.yml
+++ b/.github/workflows/calendars.yml
@@ -66,7 +66,6 @@ jobs:
       CALDAV_OUTBOUND_API_KEY: test-outbound-key
       CALDAV_INBOUND_API_KEY: test-inbound-key
       CALDAV_INTERNAL_API_KEY: test-internal-key
-      CALDAV_CALLBACK_HOST: localhost
       TRANSLATIONS_JSON_PATH: ${{ github.workspace }}/src/frontend/apps/calendars/src/features/i18n/translations.json
 
     steps:
@@ -93,6 +92,7 @@ jobs:
             -e CALDAV_INBOUND_API_KEY=test-inbound-key \
             -e CALDAV_OUTBOUND_API_KEY=test-outbound-key \
             -e CALDAV_INTERNAL_API_KEY=test-internal-key \
+            -e CALDAV_CALLBACK_BASE_URL=http://localhost:8001 \
             caldav-test \
             sh -c "/usr/local/bin/init-database.sh && apache2-foreground"
 

--- a/bin/pytest
+++ b/bin/pytest
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
+# Point CalDAV scheduling callbacks to the test callback server (port 8001)
+# instead of the Django dev server. compose.yaml interpolates this into
+# the caldav service's environment.
+export CALDAV_CALLBACK_BASE_URL="http://backend-test:8001"
+
 source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+# Ensure the caldav container uses the test callback URL
+_docker_compose up -d caldav
 
 # Use the dedicated backend-test compose service so tests don't inherit
 # env.d/development/backend.local. The Test settings class is selected

--- a/compose.yaml
+++ b/compose.yaml
@@ -151,6 +151,9 @@ services:
     env_file:
       - env.d/development/caldav.defaults
       - env.d/development/caldav.local
+    environment:
+      # Allow shell override for tests (bin/pytest sets this to backend-test:8001)
+      CALDAV_CALLBACK_BASE_URL: ${CALDAV_CALLBACK_BASE_URL:-http://backend-dev:8000}
     volumes:
       - ./src/caldav/server.php:/var/www/sabredav/server.php
       - ./src/caldav/src:/var/www/sabredav/src

--- a/docs/invitations.md
+++ b/docs/invitations.md
@@ -25,8 +25,8 @@ Frontend (EventModal)
    and `ORGANIZER` properties
 3. `CalDavService.createEvent()` sends a PUT to CalDAV through the
    Django proxy
-4. The proxy (`CalDAVProxyView`) injects an
-   `X-LS-Callback-URL` header pointing back to Django
+4. SabreDAV uses its `CALDAV_CALLBACK_BASE_URL` env var to call
+   back to Django
 
 The resulting `.ics` contains:
 
@@ -153,7 +153,7 @@ When an event with attendees is deleted:
 | `CALDAV_URL` | `http://caldav:80` | Internal CalDAV server URL |
 | `CALDAV_INBOUND_API_KEY` | None | API key for callbacks from CalDAV |
 | `CALDAV_OUTBOUND_API_KEY` | None | API key for requests to CalDAV |
-| `CALDAV_CALLBACK_BASE_URL` | None | Internal URL for CalDAV→Django (Docker: `http://backend:8000`) |
+| `CALDAV_CALLBACK_BASE_URL` | **required** | Base URL for CalDAV→Django callbacks (e.g. `http://backend:8000`). Set on the CalDAV container. |
 | `CALENDAR_ITIP_ENABLED` | False | Use iTIP METHOD headers in ICS attachments |
 | `CALENDAR_INVITATION_FROM_EMAIL` | `DEFAULT_FROM_EMAIL` | Sender address for invitation emails |
 | `APP_URL` | `""` | Base URL for RSVP links in emails |

--- a/env.d/development/backend.defaults
+++ b/env.d/development/backend.defaults
@@ -51,9 +51,6 @@ CALDAV_URL=http://caldav:80
 CALDAV_OUTBOUND_API_KEY=changeme-outbound-in-production
 CALDAV_INBOUND_API_KEY=changeme-inbound-in-production
 CALDAV_INTERNAL_API_KEY=changeme-internal-in-production
-# Internal URL for CalDAV scheduling callbacks (accessible from CalDAV container)
-CALDAV_CALLBACK_BASE_URL=http://backend-dev:8000
-
 # Frontend
 FRONTEND_THEME=default
 FRONTEND_MORE_LINK=

--- a/env.d/development/caldav.defaults
+++ b/env.d/development/caldav.defaults
@@ -7,9 +7,8 @@ CALDAV_BASE_URI=/caldav/
 CALDAV_INBOUND_API_KEY=changeme-inbound-in-production
 CALDAV_OUTBOUND_API_KEY=changeme-outbound-in-production
 CALDAV_INTERNAL_API_KEY=changeme-internal-in-production
-# Default callback URL for sending scheduling notifications (emails)
-# Used when clients (like Apple Calendar) don't provide X-CalDAV-Callback-URL header
-CALDAV_CALLBACK_URL=http://backend-dev:8000/api/v1.0/caldav-scheduling-callback
+# Base URL for the Django backend (used by SabreDAV for scheduling callbacks)
+CALDAV_CALLBACK_BASE_URL=http://backend-dev:8000
 # Calendar sanitizer: strip inline binary attachments (base64 images from Outlook/Exchange)
 # Applies to all CalDAV writes (client PUTs + import)
 SANITIZER_STRIP_BINARY_ATTACHMENTS=true

--- a/src/backend/calendars/settings.py
+++ b/src/backend/calendars/settings.py
@@ -115,12 +115,6 @@ class Base(Configuration):
         environ_name="SALT_KEY",
         environ_prefix=None,
     )
-    # Base URL for CalDAV scheduling callbacks (must be accessible from CalDAV container)
-    # In Docker environments, use the internal Docker network URL (e.g., http://backend:8000)
-    CALDAV_CALLBACK_BASE_URL = values.Value(
-        None, environ_name="CALDAV_CALLBACK_BASE_URL", environ_prefix=None
-    )
-
     # Email configuration
     # Default settings - override in environment-specific classes
     EMAIL_BACKEND = values.Value(

--- a/src/backend/core/api/viewsets_caldav.py
+++ b/src/backend/core/api/viewsets_caldav.py
@@ -7,7 +7,6 @@ import secrets
 from django.conf import settings
 from django.core.validators import validate_email
 from django.http import HttpResponse
-from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views import View
@@ -213,21 +212,6 @@ class CalDAVProxyView(View):
         # doubles as the audit principal — AuditContextPlugin reads
         # the same header for setCurrentPrincipal(). One header,
         # one source of "who is acting".
-
-        # Add callback URL for CalDAV scheduling (iTip/iMip)
-        # The CalDAV server will call this URL when it needs to send invitations
-        # Use CALDAV_CALLBACK_BASE_URL if configured (for Docker environments where
-        # the CalDAV container needs to reach Django via internal network)
-        callback_path = reverse("caldav-scheduling-callback")
-        callback_base_url = settings.CALDAV_CALLBACK_BASE_URL
-        if callback_base_url:
-            # Use configured internal URL (e.g., http://backend:8000)
-            headers["X-LS-Callback-URL"] = (
-                f"{callback_base_url.rstrip('/')}{callback_path}"
-            )
-        else:
-            # Fall back to external URL (works when CalDAV can reach Django externally)
-            headers["X-LS-Callback-URL"] = request.build_absolute_uri(callback_path)
 
         # No Basic Auth - our custom backend uses X-LS-User header and API key
         auth = None

--- a/src/backend/core/services/translation_service.py
+++ b/src/backend/core/services/translation_service.py
@@ -142,7 +142,7 @@ class TranslationService:
         or "Thursday, January 23, 2026" (en).
         """
         weekday = cls.t(f"calendar.weekdaysFull.{WEEKDAY_KEYS[dt.weekday()]}", lang)
-        month = cls.t(f"calendar.recurrence.months.{MONTH_KEYS[dt.month]}", lang)
+        month = cls.t(f"calendar.recurrence.monthNames.{MONTH_KEYS[dt.month]}", lang)
 
         if lang == "fr":
             month = month.lower()

--- a/src/backend/core/tests/test_caldav_scheduling.py
+++ b/src/backend/core/tests/test_caldav_scheduling.py
@@ -4,7 +4,6 @@
 
 import http.server
 import logging
-import os
 import secrets
 import socket
 import threading
@@ -89,8 +88,8 @@ class TestCalDAVScheduling:
         This test verifies that when an event is created with an attendee via CalDAV,
         the HttpCallbackIMipPlugin sends a scheduling message to the Django callback endpoint.
 
-        The test starts a local HTTP server to receive the callback, and passes the server URL
-        to the CalDAV server via the X-LS-Callback-URL header.
+        The test starts a local HTTP server on port 8001 to receive the callback.
+        The CalDAV server's CALDAV_CALLBACK_BASE_URL env var must point to this server.
         """
         # Create users: organizer
         # Note: attendee should be external (not in CalDAV server) to trigger scheduling
@@ -121,18 +120,10 @@ class TestCalDAVScheduling:
         except OSError as e:
             pytest.fail(f"Test server failed to start on port {port}: {e}")
 
-        # In Docker Compose, use the container hostname; on bare host (CI), use localhost
-        callback_host = os.environ.get("CALDAV_CALLBACK_HOST", "backend-test")
-        callback_url = f"http://{callback_host}:{port}/"
-
         try:
             # Create an event with an attendee
             client = service._get_client(organizer)  # pylint: disable=protected-access
             calendar_url = service._calendar_url(caldav_path)  # pylint: disable=protected-access
-
-            # Add custom callback URL header to the client
-            # The CalDAV server will use this URL for the callback
-            client.headers["X-LS-Callback-URL"] = callback_url
 
             try:
                 caldav_calendar = client.calendar(url=calendar_url)
@@ -251,100 +242,6 @@ END:VCALENDAR"""
             server.shutdown()
             server.server_close()
 
-    @pytest.mark.parametrize(
-        "scheme_url",
-        [
-            "file:///etc/passwd",
-            "gopher://backend-test:8001/_GET",
-            "dict://backend-test:8001/info",
-            "ldap://backend-test:8001/",
-            "ftp://backend-test:8001/",
-        ],
-    )
-    def test_scheduling_callback_rejects_non_http_scheme(self, scheme_url):
-        """X-LS-Callback-URL with a non-http(s) scheme must be refused.
-
-        Regression for the HttpCallbackIMipPlugin SSRF: previously the
-        plugin handed the header value straight to ``curl_init`` with no
-        scheme/protocol restriction. A caller that reached caldav directly
-        (bypassing the Django proxy) and held the outbound API key could
-        set the header to ``file://``, ``gopher://``, ``dict://``, etc.
-        and have curl deliver the iCalendar payload — and the outbound
-        API key in the headers — to any reachable endpoint.
-
-        We assert two things:
-          1. The PUT itself succeeds (the plugin must fail gracefully,
-             not crash, when the scheme is rejected).
-          2. The test HTTP server we started on the *control* port is
-             NEVER contacted, because curl is also pinned to http(s) via
-             ``CURLOPT_PROTOCOLS`` so a ``gopher://`` URL with the same
-             host:port can't reach it.
-        """
-        organizer = factories.UserFactory(
-            email=f"organizer-ssrf-{secrets.token_hex(4)}@example.com"
-        )
-        service = CalendarService()
-        caldav_path = service.create_calendar(
-            organizer, name="SSRF Test Calendar", color="#ff0000"
-        )
-
-        # Start a real test server on the same host:port the gopher/dict
-        # URLs target. If the rejection is broken and curl follows through
-        # in some weird way, the server would observe the request.
-        server, port, callback_data = create_test_server()
-        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
-        server_thread.start()
-        time.sleep(0.5)
-
-        try:
-            # Build a hostile callback URL on the SAME host:port the test
-            # server is listening on, so we can detect any leak.
-            callback_host = os.environ.get("CALDAV_CALLBACK_HOST", "backend-test")
-            hostile_url = scheme_url.replace(
-                "backend-test:8001", f"{callback_host}:{port}"
-            )
-
-            client = service._get_client(organizer)  # pylint: disable=protected-access
-            client.headers["X-LS-Callback-URL"] = hostile_url
-            calendar_url = service._calendar_url(caldav_path)  # pylint: disable=protected-access
-
-            try:
-                caldav_calendar = client.calendar(url=calendar_url)
-                dtstart = datetime.now() + timedelta(days=1)
-                dtend = dtstart + timedelta(hours=1)
-                ical_content = f"""BEGIN:VCALENDAR
-VERSION:2.0
-PRODID:-//Test//Test Client//EN
-BEGIN:VEVENT
-UID:ssrf-test-{datetime.now().timestamp()}
-DTSTART:{dtstart.strftime("%Y%m%dT%H%M%SZ")}
-DTEND:{dtend.strftime("%Y%m%dT%H%M%SZ")}
-SUMMARY:SSRF Probe
-ORGANIZER;CN=Organizer:mailto:{organizer.email}
-ATTENDEE;CN=External;RSVP=TRUE:mailto:external-ssrf@external-domain.com
-END:VEVENT
-END:VCALENDAR"""
-
-                # The PUT must SUCCEED — rejection happens inside the
-                # schedule plugin and is reported via Schedule-Status,
-                # not via an HTTP error on the calendar object PUT.
-                caldav_calendar.save_event(ical_content)
-
-                # Give any (mistakenly-fired) callback time to land.
-                time.sleep(2)
-
-                assert not callback_data["called"], (
-                    f"Hostile callback URL {hostile_url!r} reached the test "
-                    f"server — the SSRF guard in HttpCallbackIMipPlugin "
-                    f"failed to reject the non-http scheme. Captured request: "
-                    f"{callback_data['request_data']}"
-                )
-            except NotFoundError:
-                pytest.skip("Calendar not found - CalDAV server may not be running")
-        finally:
-            server.shutdown()
-            server.server_close()
-
     def test_scheduling_callback_for_shared_mailbox_calendar(  # noqa: PLR0915  # pylint: disable=too-many-locals,too-many-statements,redefined-outer-name,unused-variable,no-member
         self,
     ):
@@ -453,14 +350,10 @@ END:VCALENDAR"""
         server_thread.start()
         time.sleep(0.5)
 
-        callback_host = os.environ.get("CALDAV_CALLBACK_HOST", "backend-test")
-        callback_url = f"http://{callback_host}:{port}/"
-
         try:
             # 4. Create a CalDAV client authenticated as the user
             service = CalendarService()
             client = service._get_client(user)  # pylint: disable=protected-access
-            client.headers["X-LS-Callback-URL"] = callback_url
 
             # Use the shared calendar URL discovered earlier
             calendar_url = shared_cal_url
@@ -595,16 +488,14 @@ class TestOrganizerSpoofingRejection:
         org = factories.OrganizationFactory(external_id=f"spoof-{secrets.token_hex(4)}")
         user, _, cal_path = _create_user_with_calendar(org, "spoof-attacker")
 
-        server, port, callback_data = create_test_server()
+        server, _, callback_data = create_test_server()
         server_thread = threading.Thread(target=server.serve_forever, daemon=True)
         server_thread.start()
         time.sleep(0.5)
 
         try:
-            callback_host = os.environ.get("CALDAV_CALLBACK_HOST", "backend-test")
             service = CalendarService()
             client = service._get_client(user)  # pylint: disable=protected-access
-            client.headers["X-LS-Callback-URL"] = f"http://{callback_host}:{port}/"
             calendar_url = service._calendar_url(cal_path)  # pylint: disable=protected-access
             caldav_calendar = client.calendar(url=calendar_url)
 
@@ -644,16 +535,14 @@ class TestOrganizerSpoofingRejection:
         )
         user, _, cal_path = _create_user_with_calendar(org, "spoof-control")
 
-        server, port, callback_data = create_test_server()
+        server, _, callback_data = create_test_server()
         server_thread = threading.Thread(target=server.serve_forever, daemon=True)
         server_thread.start()
         time.sleep(0.5)
 
         try:
-            callback_host = os.environ.get("CALDAV_CALLBACK_HOST", "backend-test")
             service = CalendarService()
             client = service._get_client(user)  # pylint: disable=protected-access
-            client.headers["X-LS-Callback-URL"] = f"http://{callback_host}:{port}/"
             calendar_url = service._calendar_url(cal_path)  # pylint: disable=protected-access
             caldav_calendar = client.calendar(url=calendar_url)
 

--- a/src/caldav/server.php
+++ b/src/caldav/server.php
@@ -230,18 +230,20 @@ $server->addPlugin(new InternalApiPlugin($pdo, $caldavBackend, $internalApiKey))
 
 // Add custom IMipPlugin that forwards scheduling messages via HTTP callback
 // This MUST be added BEFORE the Schedule\Plugin so that Schedule\Plugin finds it
-// The callback URL can be provided per-request via X-LS-Callback-URL header
-// or via CALDAV_CALLBACK_URL environment variable as fallback
+// The callback URL is built from CALDAV_CALLBACK_BASE_URL + fixed path
 $callbackApiKey = getenv('CALDAV_INBOUND_API_KEY');
 if (!$callbackApiKey) {
     error_log("[sabre/dav] CALDAV_INBOUND_API_KEY environment variable is required for scheduling callback");
     exit(1);
 }
-$defaultCallbackUrl = getenv('CALDAV_CALLBACK_URL') ?: null;
-if ($defaultCallbackUrl) {
-    error_log("[sabre/dav] Using default callback URL for scheduling: {$defaultCallbackUrl}");
+$callbackBaseUrl = getenv('CALDAV_CALLBACK_BASE_URL');
+if (!$callbackBaseUrl) {
+    error_log("[sabre/dav] CALDAV_CALLBACK_BASE_URL environment variable is required for scheduling callback");
+    exit(1);
 }
-$imipPlugin = new HttpCallbackIMipPlugin($callbackApiKey, $pdo, $defaultCallbackUrl);
+$callbackUrl = rtrim($callbackBaseUrl, '/') . '/api/v1.0/caldav-scheduling-callback/';
+error_log("[sabre/dav] Scheduling callback URL: {$callbackUrl}");
+$imipPlugin = new HttpCallbackIMipPlugin($callbackApiKey, $pdo, $callbackUrl);
 $server->addPlugin($imipPlugin);
 
 // Enforce org-level freebusy sharing settings

--- a/src/caldav/src/HttpCallbackIMipPlugin.php
+++ b/src/caldav/src/HttpCallbackIMipPlugin.php
@@ -34,26 +34,26 @@ class HttpCallbackIMipPlugin extends IMipPlugin
     private $pdo;
 
     /**
-     * Default callback URL (fallback if header is not provided)
-     * @var string|null
+     * Callback URL set at startup from CALDAV_CALLBACK_BASE_URL
+     * @var string
      */
-    private $defaultCallbackUrl;
+    private $callbackUrl;
 
     /**
      * Constructor
      *
      * @param string $apiKey The API key for authenticating with the callback endpoint
      * @param \PDO $pdo Database connection for principal lookups
-     * @param string|null $defaultCallbackUrl Optional default callback URL
+     * @param string $callbackUrl The callback URL (base URL + path, built at startup)
      */
-    public function __construct($apiKey, \PDO $pdo, $defaultCallbackUrl = null)
+    public function __construct($apiKey, \PDO $pdo, $callbackUrl)
     {
         // Call parent constructor with empty email (we won't use it)
         parent::__construct('');
 
         $this->apiKey = $apiKey;
         $this->pdo = $pdo;
-        $this->defaultCallbackUrl = $defaultCallbackUrl;
+        $this->callbackUrl = rtrim($callbackUrl, '/') . '/';
     }
 
     /**
@@ -96,47 +96,6 @@ class HttpCallbackIMipPlugin extends IMipPlugin
             return;
         }
 
-        // Get callback URL from the HTTP request header or use default
-        $callbackUrl = null;
-        if ($this->server && $this->server->httpRequest) {
-            $callbackUrl = $this->server->httpRequest->getHeader('X-LS-Callback-URL');
-        }
-
-        // Fall back to default callback URL if header is not provided
-        if (!$callbackUrl && $this->defaultCallbackUrl) {
-            $callbackUrl = $this->defaultCallbackUrl;
-            error_log("[HttpCallbackIMipPlugin] Using default callback URL: {$callbackUrl}");
-        }
-
-        if (!$callbackUrl) {
-            error_log("[HttpCallbackIMipPlugin] ERROR: X-LS-Callback-URL header or default URL is required");
-            $iTipMessage->scheduleStatus = '5.4;X-LS-Callback-URL header or default URL is required';
-            return;
-        }
-
-        // Ensure URL ends with trailing slash for Django's APPEND_SLASH middleware
-        $callbackUrl = rtrim($callbackUrl, '/') . '/';
-
-        // SSRF guard: only allow http(s). Without this, a caller that
-        // reaches caldav directly (bypassing the Django proxy) and holds
-        // the outbound API key could set ``X-LS-Callback-URL`` to e.g.
-        // ``file:///etc/passwd``, ``gopher://internal-redis:6379/_SET…``
-        // or ``dict://…`` and have curl deliver the iCalendar payload —
-        // and the outbound API key in the headers — wherever they want.
-        // The Django proxy already strips ``HTTP_X_LS_*`` from incoming
-        // requests and overrides this header, so legit users can't reach
-        // here at all; the guard exists to keep the blast radius small
-        // when someone with the outbound key talks to caldav directly.
-        $callbackScheme = strtolower((string) parse_url($callbackUrl, PHP_URL_SCHEME));
-        if ($callbackScheme !== 'http' && $callbackScheme !== 'https') {
-            error_log(
-                "[HttpCallbackIMipPlugin] ERROR: refusing callback URL with "
-                . "non-http(s) scheme: " . $callbackScheme
-            );
-            $iTipMessage->scheduleStatus = '5.4;Callback URL must use http(s) scheme';
-            return;
-        }
-
         // Serialize the iCalendar message
         $vcalendar = $iTipMessage->message ? $iTipMessage->message->serialize() : '';
         
@@ -167,19 +126,13 @@ class HttpCallbackIMipPlugin extends IMipPlugin
         }
         
         // Make HTTP POST request to Django callback endpoint.
-        // CURLOPT_PROTOCOLS / CURLOPT_REDIR_PROTOCOLS pin curl to http(s)
-        // so even a (currently disabled) redirect cannot escape into
-        // file://, gopher://, dict://, ldap://, etc. — defense in depth
-        // alongside the scheme allowlist above.
-        $ch = curl_init($callbackUrl);
+        $ch = curl_init($this->callbackUrl);
         curl_setopt_array($ch, [
             CURLOPT_POST => true,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HTTPHEADER => $headers,
             CURLOPT_POSTFIELDS => $vcalendar,
             CURLOPT_TIMEOUT => 10,
-            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
             CURLOPT_FOLLOWLOCATION => false,
         ]);
         


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * CalDAV scheduling callbacks now rely on a single required base URL environment setting, centralizing callback routing for tests and deployments.

* **Documentation**
  * Updated CalDAV callback docs to reflect the new required base URL and provide setup examples.

* **Testing**
  * Test scripts and CI updated to start the CalDAV service and target the configured callback base URL for more reliable runs.

* **Bug Fixes**
  * Fixed month-name translation lookup to use the correct translation key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->