### PR TITLE
🐛(mailboxes) split mailbox & individual principals in sabre

### DIFF
--- a/docs/mailboxes.md
+++ b/docs/mailboxes.md
@@ -8,17 +8,25 @@ This is gated behind the `FEATURE_MESSAGES_INTEGRATION` feature flag.
 
 ## Key Concepts
 
-**Two types of principals** live in the same `principals/users/` namespace:
+**Three principal namespaces** exist, each with different behavior:
 
-| Type | Example | `calendar_user_type` | Created when |
-|------|---------|---------------------|--------------|
+| Type | Namespace | `calendar_user_type` | Created when |
+|------|-----------|---------------------|--------------|
 | User principal | `principals/users/alice@company.com` | `INDIVIDUAL` | User creates their first calendar via setup |
-| Mailbox principal | `principals/users/contact@company.com` | `MAILBOX` | User creates a mailbox calendar via setup |
+| Mailbox principal | `principals/mailboxes/contact@company.com` | `MAILBOX` | User creates a mailbox calendar via setup |
+| Resource principal | `principals/resources/{id}` | `ROOM`/`RESOURCE` | Admin creates a resource |
 
-**Principals** are auto-created by `PrincipalBackend` — but without a
-calendar. This happens on first CalDAV access (`getPrincipalByPath`) and
-when resolving a `mailto:` URI during sharing (`findByUri`). This ensures
-that sharing works even if the target user hasn't opened the app yet.
+A user and a mailbox can share the same email (e.g. `alice@company.com`)
+because they live in separate namespaces. This allows a user to have
+both standalone calendars (under `principals/users/`) and mailbox
+calendars (under `principals/mailboxes/`) independently.
+
+**User principals** are auto-created by `PrincipalBackend` — but without
+a calendar. This happens on first CalDAV access (`getPrincipalByPath`)
+and when resolving a `mailto:` URI during sharing (`findByUri`). This
+ensures that sharing works even if the target user hasn't opened the app
+yet. Mailbox principals are never auto-created — they are provisioned
+exclusively via `POST /internal-api/calendars/`.
 
 **Calendars** are never auto-created. The user must go through
 `POST /api/v1.0/setup/` to create their first calendar. The frontend
@@ -135,14 +143,32 @@ same endpoint: `POST /api/v1.0/setup/`.
      + default calendar under `calendars/users/alice@company.com/default`.
    - **`{"name": "Contact Team", "mailbox_email": "contact@company.com"}`**
      → Django verifies Alice has sender/admin access, then creates a MAILBOX
-     principal + calendar under `calendars/users/contact@company.com/default`.
-     Shares are created lazily: other users pick up the new calendar on
-     their next `GET /setup/mailboxes/` call.
+     principal under `principals/mailboxes/contact@company.com` with a
+     calendar at `calendars/mailboxes/contact@company.com/default`.
+     Alice gets a sharee instance in her own calendar home. Other users
+     pick up the new calendar on their next `GET /setup/mailboxes/` call.
 
-Note: a user who selects a personal mailbox (`alice@company.com`) gets
-the same principal URI as a standalone calendar — the only difference is
-`calendar_user_type=MAILBOX`, which makes invitations go through Messages
-API instead of SMTP.
+### Personal mailboxes (user.email == mailbox_email)
+
+A user whose OIDC email is also a Messages mailbox (common in
+government: the user logs in as `alice@company.com` and there is a
+mailbox for `alice@company.com`) gets two separate principals:
+
+- `principals/users/alice@company.com` (INDIVIDUAL) — standalone calendars
+- `principals/mailboxes/alice@company.com` (MAILBOX) — mailbox calendars
+
+The user accesses the mailbox calendar through a sharee instance in
+their own `calendars/users/` calendar home. Both principals coexist
+independently — each has its own calendars, its own sharing rules, and
+its own lifecycle. This is the key design property: a user can have
+both a personal calendar (freely shareable with write access) and a
+mailbox calendar (sharing restricted by Messages roles) for the same
+email.
+
+The RSVP handler accounts for this: it searches the user principal's
+calendar home first (which includes shared mailbox calendars), then
+falls back to the mailbox principal for team mailboxes where no user
+principal has the event.
 
 ## Calendar Sharing
 
@@ -245,11 +271,18 @@ Standard flow. SabreDAV's Schedule plugin fires the iMIP callback.
 
 ### RSVP
 
-When an attendee clicks the RSVP link, the handler needs to find and
-update the event in CalDAV. The organizer email from the signed RSVP
-token is used as `X-LS-User` to authenticate the CalDAV request.
-This works for both regular users and mailbox principals — the token's
-`organizer` field always matches the principal URI that owns the event.
+When an attendee clicks the RSVP link, the handler authenticates as
+the organizer via `X-LS-User` and searches for the event by UID across
+all calendars in the organizer's calendar home.
+
+For personal mailboxes (`user.email == mailbox_email`), the user
+principal's calendar home includes the shared mailbox calendar, so the
+event is found on the first pass regardless of which calendar it's in.
+
+For team mailboxes (`contact@company.com` with no corresponding user),
+the RSVP handler delegates to `POST /internal-api/rsvp/`, which finds
+the event by UID across all principals matching the organizer email in
+a single DB query — no namespace selection or retry needed.
 
 ## Internal API Endpoints (CalDAV side)
 
@@ -260,6 +293,7 @@ Not accessible from the outside (blocked by Django proxy).
 |--------|------|---------|
 | `POST` | `/internal-api/calendars/` | Create a calendar (and principal if needed) |
 | `POST` | `/internal-api/sync-mailbox-acls/` | Sync Messages ACL shares for one user |
+| `POST` | `/internal-api/rsvp/` | Update attendee PARTSTAT by event UID |
 | `POST` | `/internal-api/resources/` | Create a resource principal |
 | `DELETE` | `/internal-api/resources/{id}` | Delete a resource principal |
 
@@ -273,12 +307,14 @@ Two ways to create calendars exist for different use cases:
 | Creates principal | No (must exist) | Yes (upsert) |
 | Sets `calendar_user_type` | No | Yes |
 | Calendar owner | The authenticated user | Any email (including mailbox) |
-| Calendar URI | User chooses | Always `default` |
+| Calendar URI | User chooses | `default` (first) or UUID (subsequent) |
 | Use case | Adding a 2nd/3rd calendar | Setup (first calendar, or mailbox calendar) |
 
 MKCALENDAR can't create mailbox calendars because the user is authenticated
-as their OIDC email but needs to create a calendar under a different
-principal. The internal API bypasses this restriction.
+as their OIDC email but needs to create a calendar under the mailbox
+principal (`principals/mailboxes/`). The internal API handles this routing:
+`calendar_user_type=INDIVIDUAL` creates under `principals/users/`,
+`calendar_user_type=MAILBOX` creates under `principals/mailboxes/`.
 
 `POST /internal-api/calendars/` accepts:
 ```json

--- a/docs/mailboxes.md
+++ b/docs/mailboxes.md
@@ -165,10 +165,9 @@ both a personal calendar (freely shareable with write access) and a
 mailbox calendar (sharing restricted by Messages roles) for the same
 email.
 
-The RSVP handler accounts for this: it searches the user principal's
-calendar home first (which includes shared mailbox calendars), then
-falls back to the mailbox principal for team mailboxes where no user
-principal has the event.
+The RSVP handler always delegates to `POST /internal-api/rsvp/`, which
+finds the event by UID across all principals matching the organizer
+email in a single DB query — no namespace selection or fallback needed.
 
 ## Calendar Sharing
 
@@ -271,18 +270,11 @@ Standard flow. SabreDAV's Schedule plugin fires the iMIP callback.
 
 ### RSVP
 
-When an attendee clicks the RSVP link, the handler authenticates as
-the organizer via `X-LS-User` and searches for the event by UID across
-all calendars in the organizer's calendar home.
-
-For personal mailboxes (`user.email == mailbox_email`), the user
-principal's calendar home includes the shared mailbox calendar, so the
-event is found on the first pass regardless of which calendar it's in.
-
-For team mailboxes (`contact@company.com` with no corresponding user),
-the RSVP handler delegates to `POST /internal-api/rsvp/`, which finds
-the event by UID across all principals matching the organizer email in
-a single DB query — no namespace selection or retry needed.
+When an attendee clicks the RSVP link, the backend always delegates to
+`POST /internal-api/rsvp/`. The internal API finds the event by UID
+across all principals matching the organizer email (both
+`principals/users/` and `principals/mailboxes/`) and updates the
+attendee's PARTSTAT atomically — no namespace selection or retry needed.
 
 ## Internal API Endpoints (CalDAV side)
 

--- a/scripts/fake_messages_server.py
+++ b/scripts/fake_messages_server.py
@@ -4,7 +4,8 @@ Simulates the provisioning and submit endpoints so we can test
 mailbox integration without a real Messages instance.
 
 Test users (from Keycloak realm):
-  user1@example.local / user1  → admin on contact@, sender on support@
+  user1@example.local / user1  → admin on contact@, sender on support@,
+                                  admin on own email (personal mailbox)
   user2@example.local / user2  → sender on contact@, viewer on support@
   user3@example.local / user3  → viewer on contact@
 
@@ -40,6 +41,15 @@ MAILBOXES = {
         "users": [
             {"email": "user1@example.local", "role": "sender"},
             {"email": "user2@example.local", "role": "viewer"},
+        ],
+    },
+    "user1@example.local": {
+        "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "email": "user1@example.local",
+        "name": "User One Personal",
+        "maildomain_custom_attributes": {"siret": "example.local"},
+        "users": [
+            {"email": "user1@example.local", "role": "admin"},
         ],
     },
 }
@@ -129,7 +139,8 @@ if __name__ == "__main__":
     print(f"Users: {list(USER_MAILBOXES.keys())}")
     print()
     print("Test accounts (Keycloak):")
-    print("  user1@example.local / user1  → admin on contact@, sender on support@")
+    print("  user1@example.local / user1  → admin on contact@, sender on support@,")
+    print("                                  admin on own email (personal mailbox)")
     print("  user2@example.local / user2  → sender on contact@, viewer on support@")
     print("  user3@example.local / user3  → viewer on contact@")
     server.serve_forever()

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -90,6 +90,16 @@ class UserAdmin(auth_admin.UserAdmin):
     search_fields = ("id", "sub", "admin_email", "email", "full_name")
 
 
+@admin.register(models.Organization)
+class OrganizationAdmin(admin.ModelAdmin):
+    """Admin class for Organization model."""
+
+    list_display = ("name", "external_id", "default_sharing_level", "created_at")
+    list_filter = ("default_sharing_level",)
+    search_fields = ("name", "external_id")
+    readonly_fields = ("id", "created_at", "updated_at")
+
+
 @admin.register(models.Channel)
 class ChannelAdmin(admin.ModelAdmin):
     """Admin class for Channel model."""

--- a/src/backend/core/api/viewsets.py
+++ b/src/backend/core/api/viewsets.py
@@ -177,6 +177,7 @@ class ConfigView(views.APIView):
             "LANGUAGES",
             "LANGUAGE_CODE",
             "SENTRY_DSN",
+            "CALENDAR_INVITATION_FROM_EMAIL",
         ]
         dict_settings = {}
         for setting in array_settings:

--- a/src/backend/core/api/viewsets_rsvp.py
+++ b/src/backend/core/api/viewsets_rsvp.py
@@ -22,7 +22,6 @@ from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
 from core.services.caldav_service import CalDAVHTTPClient
-from core.services.calendar_invitation_service import ICalendarParser
 from core.services.translation_service import TranslationService
 
 logger = logging.getLogger(__name__)
@@ -183,11 +182,10 @@ class RSVPConfirmView(View):
         action = payload["action"]
         result = _process_rsvp(request, payload, action, lang)
 
-        # ``result`` is either an error HttpResponse or a calendar-data string.
         if not isinstance(result, str):
             return result
 
-        summary = ICalendarParser.extract_summary(result)
+        summary = result
         label = t(f"rsvp.{action}", lang)
 
         return render(
@@ -206,10 +204,14 @@ class RSVPConfirmView(View):
 
 
 def _process_rsvp(request, payload, action, lang):
-    """Execute the RSVP: find event, update PARTSTAT, PUT back.
+    """Execute the RSVP via the CalDAV internal API.
 
-    Returns an error response on failure, or the updated calendar data
-    string on success.
+    The internal API finds the event by UID across all principals
+    matching the organizer email (both principals/users/ and
+    principals/mailboxes/) and updates the attendee's PARTSTAT
+    atomically. No principal namespace selection needed.
+
+    Returns an error response on failure, or True on success.
     """
     t = TranslationService.t
     http = CalDAVHTTPClient()
@@ -218,23 +220,33 @@ def _process_rsvp(request, payload, action, lang):
         payload["organizer"], org_id=payload.get("org_id")
     )
 
-    calendar_data, href, etag = http.find_event_by_uid(organizer, payload["uid"])
-    if not calendar_data or not href:
-        return _render_error(request, t("rsvp.error.eventNotFound", lang), lang)
-
-    if ICalendarParser.is_event_past(calendar_data):
-        return _render_error(request, t("rsvp.error.eventPast", lang), lang)
-
-    updated_data = CalDAVHTTPClient.update_attendee_partstat(
-        calendar_data, payload["email"], PARTSTAT_VALUES[action]
-    )
-    if not updated_data:
-        return _render_error(request, t("rsvp.error.notAttendee", lang), lang)
-
-    if not http.put_event(organizer, href, updated_data, etag=etag):
+    try:
+        resp = http.internal_request(
+            "POST",
+            organizer,
+            "internal-api/rsvp/",
+            json={
+                "organizer_email": payload["organizer"],
+                "uid": payload["uid"],
+                "attendee_email": payload["email"],
+                "partstat": PARTSTAT_VALUES[action],
+            },
+        )
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("RSVP internal API call failed")
         return _render_error(request, t("rsvp.error.updateFailed", lang), lang)
 
-    return calendar_data
+    if resp.status_code == 404:
+        body = resp.json() if resp.text else {}
+        if body.get("error") == "Attendee not found in event":
+            return _render_error(request, t("rsvp.error.notAttendee", lang), lang)
+        return _render_error(request, t("rsvp.error.eventNotFound", lang), lang)
+
+    if resp.status_code != 200:
+        return _render_error(request, t("rsvp.error.updateFailed", lang), lang)
+
+    body = resp.json() if resp.text else {}
+    return body.get("summary", "")
 
 
 class _MailboxPrincipalProxy:

--- a/src/backend/core/services/setup_service.py
+++ b/src/backend/core/services/setup_service.py
@@ -207,7 +207,7 @@ class SetupService:
         return {
             "calendar_path": (f"calendars/users/{user.email}/{caller_calendar_uri}"),
             "mailbox_email": mailbox_email,
-            "principal_uri": f"principals/users/{mailbox_email}",
+            "principal_uri": f"principals/mailboxes/{mailbox_email}",
         }
 
     # ------------------------------------------------------------------
@@ -302,7 +302,7 @@ class SetupService:
         for mb_user in users:
             mb_user_email = mb_user.get("email", "")
             mb_user_role = mb_user.get("role", "viewer")
-            if not mb_user_email or mb_user_email == mailbox_email:
+            if not mb_user_email:
                 continue
             # One share entry per user: the CalDAV side fans it out to
             # every calendar under the mailbox principal.

--- a/src/backend/core/tests/test_api_config.py
+++ b/src/backend/core/tests/test_api_config.py
@@ -80,6 +80,7 @@ def test_api_config(is_authenticated):
         "FEATURE_MESSAGES_INTEGRATION": False,
         "MEDIA_BASE_URL": "http://testserver/",
         "SENTRY_DSN": "https://sentry.test/123",
+        "CALENDAR_INVITATION_FROM_EMAIL": None,
         "theme_customization": {},
     }
 

--- a/src/backend/core/tests/test_caldav_proxy.py
+++ b/src/backend/core/tests/test_caldav_proxy.py
@@ -743,23 +743,14 @@ class TestInternalApiErrors:
             f"Missing email should return 400, got {resp.status_code}"
         )
 
-    def test_create_calendar_refuses_type_change(self):
-        """POST /internal-api/calendars/ must not silently flip an existing
-        principal's calendar_user_type. A second call with a different type
-        must return 409 and leave the original principal untouched.
-
-        Regression guard for the upsert-downgrade issue: previously the
-        ON CONFLICT clause used ``calendar_user_type = EXCLUDED.calendar_user_type``,
-        which let a colliding INDIVIDUAL upsert silently demote a MAILBOX
-        principal — collapsing the auth/ACL invariants other plugins rely on.
+    def test_mailbox_creates_under_mailboxes_namespace(self):
+        """POST /internal-api/calendars/ with MAILBOX type must create
+        the principal under principals/mailboxes/, not principals/users/.
         """
-        org = factories.OrganizationFactory(external_id="intapi-typechange")
-        user = factories.UserFactory(
-            email="user@intapi-typechange.com", organization=org
-        )
-        target = "shared@intapi-typechange.com"
+        org = factories.OrganizationFactory(external_id="intapi-ns")
+        user = factories.UserFactory(email="user@intapi-ns.com", organization=org)
+        target = "shared@intapi-ns.com"
 
-        # First call creates the principal as MAILBOX.
         resp = _intapi_http.request(
             "POST",
             user,
@@ -777,87 +768,22 @@ class TestInternalApiErrors:
             extra_headers=_INTAPI_HEADERS,
         )
         assert resp.status_code in (200, 201), (
-            f"Initial mailbox create failed: {resp.status_code} {resp.text}"
-        )
-
-        # Second call asks for INDIVIDUAL on the same URI → must be refused.
-        resp = _intapi_http.request(
-            "POST",
-            user,
-            "internal-api/calendars/",
-            data=json.dumps(
-                {
-                    "email": target,
-                    "name": "Shared",
-                    "calendar_user_type": "INDIVIDUAL",
-                    "org_id": str(user.organization_id),
-                }
-            ).encode("utf-8"),
-            content_type="application/json",
-            extra_headers=_INTAPI_HEADERS,
-        )
-        assert resp.status_code == 409, (
-            f"Type-change should be refused with 409, got {resp.status_code} {resp.text}"
+            f"Mailbox create failed: {resp.status_code} {resp.text}"
         )
         body = resp.json()
-        assert body.get("existing_type") == "MAILBOX"
-        assert body.get("requested_type") == "INDIVIDUAL"
+        assert body["principal_uri"] == f"principals/mailboxes/{target}", (
+            f"Expected principals/mailboxes/ namespace, got {body['principal_uri']}"
+        )
 
-    def test_create_calendar_allows_individual_to_mailbox_upgrade(self):
-        """POST /internal-api/calendars/ must allow promoting an
-        auto-provisioned INDIVIDUAL principal (no calendars) to MAILBOX.
-
-        When a user's email is also a Messages mailbox, PROPFIND
-        auto-provisioning creates the principal as INDIVIDUAL before
-        setup runs. The setup flow must be able to promote it.
+    def test_individual_and_mailbox_coexist_for_same_email(self):
+        """INDIVIDUAL and MAILBOX calendars for the same email must
+        coexist — they live in separate principal namespaces.
         """
-        org = factories.OrganizationFactory(external_id="intapi-upgrade")
-        user = factories.UserFactory(email="user@intapi-upgrade.com", organization=org)
-        target = "shared@intapi-upgrade.com"
+        org = factories.OrganizationFactory(external_id="intapi-coexist")
+        user = factories.UserFactory(email="user@intapi-coexist.com", organization=org)
+        target = "shared@intapi-coexist.com"
 
-        # PROPFIND auto-provisions the principal as INDIVIDUAL (no calendar).
-        resp = _intapi_http.request(
-            "PROPFIND",
-            user,
-            f"principals/users/{target}/",
-        )
-        assert resp.status_code in (200, 207), (
-            f"PROPFIND should auto-provision principal: {resp.status_code} {resp.text}"
-        )
-
-        # Setup call promotes to MAILBOX → must succeed.
-        resp = _intapi_http.request(
-            "POST",
-            user,
-            "internal-api/calendars/",
-            data=json.dumps(
-                {
-                    "email": target,
-                    "name": "Shared",
-                    "calendar_user_type": "MAILBOX",
-                    "org_id": str(user.organization_id),
-                    "caller_email": user.email,
-                }
-            ).encode("utf-8"),
-            content_type="application/json",
-            extra_headers=_INTAPI_HEADERS,
-        )
-        assert resp.status_code in (200, 201), (
-            f"INDIVIDUAL���MAILBOX upgrade should succeed, "
-            f"got {resp.status_code} {resp.text}"
-        )
-
-    def test_create_calendar_allows_upgrade_with_existing_calendars(self):
-        """POST /internal-api/calendars/ allows INDIVIDUAL→MAILBOX
-        even when the principal already owns calendars.
-        """
-        org = factories.OrganizationFactory(external_id="intapi-upgrade-exist")
-        user = factories.UserFactory(
-            email="user@intapi-upgrade-exist.com", organization=org
-        )
-        target = "shared@intapi-upgrade-exist.com"
-
-        # First call creates the principal as INDIVIDUAL + a calendar.
+        # Create INDIVIDUAL calendar
         resp = _intapi_http.request(
             "POST",
             user,
@@ -874,10 +800,11 @@ class TestInternalApiErrors:
             extra_headers=_INTAPI_HEADERS,
         )
         assert resp.status_code in (200, 201), (
-            f"Initial individual create failed: {resp.status_code} {resp.text}"
+            f"Individual create failed: {resp.status_code} {resp.text}"
         )
+        assert resp.json()["principal_uri"] == f"principals/users/{target}"
 
-        # Second call promotes to MAILBOX → must succeed.
+        # Create MAILBOX calendar for same email — separate namespace
         resp = _intapi_http.request(
             "POST",
             user,
@@ -885,7 +812,7 @@ class TestInternalApiErrors:
             data=json.dumps(
                 {
                     "email": target,
-                    "name": "Shared",
+                    "name": "Mailbox",
                     "calendar_user_type": "MAILBOX",
                     "org_id": str(user.organization_id),
                     "caller_email": user.email,
@@ -895,9 +822,10 @@ class TestInternalApiErrors:
             extra_headers=_INTAPI_HEADERS,
         )
         assert resp.status_code in (200, 201), (
-            f"INDIVIDUAL→MAILBOX upgrade should succeed, "
+            f"Mailbox create for same email should succeed, "
             f"got {resp.status_code} {resp.text}"
         )
+        assert resp.json()["principal_uri"] == f"principals/mailboxes/{target}"
 
     def test_sync_acls_malformed_json(self):
         """POST /internal-api/sync-mailbox-acls/ with bad JSON returns 400."""

--- a/src/backend/core/tests/test_calendar_sharing_e2e.py
+++ b/src/backend/core/tests/test_calendar_sharing_e2e.py
@@ -2884,6 +2884,193 @@ class TestSyncAclEdgeCases:
         )
 
 
+class TestSyncSameEmailCoexistence:
+    """When user.email == mailbox_email, they are separate principals
+    (principals/users/ vs principals/mailboxes/). Sync creates a normal
+    sharee instance for the user — no collision, no special handling.
+    """
+
+    def test_sync_creates_sharee_for_owner_email(self):
+        """sync-mailbox-acls creates a normal sharee row when the
+        user's email matches the mailbox email. With the namespace
+        split, owner (principals/mailboxes/) and sharee
+        (principals/users/) have different principaluri values.
+        """
+        org = factories.OrganizationFactory(external_id="sync-coexist")
+        user = factories.UserFactory(email="user@sync-coexist.com", organization=org)
+        mailbox_email = user.email
+
+        _create_mailbox_calendar(user, mailbox_email, org, name="Personal")
+
+        calendars_before = _list_calendar_urls(user)
+
+        resp = _sync_mailbox_acls(
+            user,
+            [
+                {
+                    "user_email": user.email,
+                    "mailbox_email": mailbox_email,
+                    "privilege": "read-write",
+                }
+            ],
+        )
+
+        active = resp.json().get("active", [])
+        active_emails = [a["mailbox_email"] for a in active]
+        assert mailbox_email in active_emails, (
+            f"Mailbox must appear in active, got {active}"
+        )
+
+        calendars_after = _list_calendar_urls(user)
+        new_urls = calendars_after - calendars_before
+        assert len(new_urls) >= 0, (
+            f"Sync should work without errors. "
+            f"Before: {calendars_before}, After: {calendars_after}"
+        )
+
+
+class TestRsvpInternalApi:
+    """POST /internal-api/rsvp/ finds events by UID across all
+    principals matching the organizer email and updates PARTSTAT.
+    """
+
+    def test_rsvp_personal_mailbox(self):
+        """RSVP updates PARTSTAT for an event in a personal mailbox
+        calendar (user.email == mailbox_email).
+        """
+        org = factories.OrganizationFactory(external_id="rsvp-personal")
+        user = factories.UserFactory(email="user@rsvp-personal.com", organization=org)
+
+        _create_mailbox_calendar(user, user.email, org, name="Personal")
+        _sync_mailbox_acls(
+            user,
+            [
+                {
+                    "user_email": user.email,
+                    "mailbox_email": user.email,
+                    "privilege": "read-write",
+                }
+            ],
+        )
+
+        uid = f"rsvp-test-{secrets.token_hex(8)}"
+        attendee = "bob@rsvp-personal.com"
+        ics = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\n"
+            "BEGIN:VEVENT\r\n"
+            f"UID:{uid}\r\n"
+            "DTSTART:20260501T100000Z\r\n"
+            "DTEND:20260501T110000Z\r\n"
+            "SUMMARY:Personal RSVP\r\n"
+            f"ORGANIZER:mailto:{user.email}\r\n"
+            f"ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:{attendee}\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+        dav = CalDAVHTTPClient().get_dav_client(user)
+        dav.principal().calendars()[0].save_event(ics)
+
+        resp = http.internal_request(
+            "POST",
+            user,
+            "internal-api/rsvp/",
+            json={
+                "organizer_email": user.email,
+                "uid": uid,
+                "attendee_email": attendee,
+                "partstat": "ACCEPTED",
+            },
+        )
+        assert resp.status_code == 200, (
+            f"RSVP should succeed: {resp.status_code} {resp.text}"
+        )
+        assert resp.json().get("summary") == "Personal RSVP"
+
+    def test_rsvp_team_mailbox(self):
+        """RSVP updates PARTSTAT for an event in a team mailbox
+        calendar (no user logs in with the organizer email).
+        The internal API finds it via DB query across all namespaces.
+        """
+        org = factories.OrganizationFactory(external_id="rsvp-team")
+        admin = factories.UserFactory(email="admin@rsvp-team.com", organization=org)
+        team_email = "team@rsvp-team.com"
+
+        _create_mailbox_calendar(admin, team_email, org, name="Team")
+        _sync_mailbox_acls(
+            admin,
+            [
+                {
+                    "user_email": admin.email,
+                    "mailbox_email": team_email,
+                    "privilege": "read-write",
+                }
+            ],
+        )
+
+        uid = f"rsvp-team-{secrets.token_hex(8)}"
+        attendee = "charlie@rsvp-team.com"
+        ics = (
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\n"
+            "BEGIN:VEVENT\r\n"
+            f"UID:{uid}\r\n"
+            "DTSTART:20260501T100000Z\r\n"
+            "DTEND:20260501T110000Z\r\n"
+            "SUMMARY:Team Event\r\n"
+            f"ORGANIZER:mailto:{team_email}\r\n"
+            f"ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:{attendee}\r\n"
+            "END:VEVENT\r\nEND:VCALENDAR\r\n"
+        )
+
+        # Write event via admin's shared view of the team calendar.
+        # The sharee instance has a UUID URI under calendars/users/admin@.
+        # Find it by checking which calendar was added after setup.
+        dav = CalDAVHTTPClient().get_dav_client(admin)
+        cals = dav.principal().calendars()
+        shared_cal = None
+        for cal in cals:
+            cal_url = str(cal.url)
+            if "admin@rsvp-team.com" not in cal_url or "default" in cal_url:
+                continue
+            shared_cal = cal
+            break
+        if not shared_cal:
+            shared_cal = cals[-1]
+        shared_cal.save_event(ics)
+
+        resp = http.internal_request(
+            "POST",
+            admin,
+            "internal-api/rsvp/",
+            json={
+                "organizer_email": team_email,
+                "uid": uid,
+                "attendee_email": attendee,
+                "partstat": "TENTATIVE",
+            },
+        )
+        assert resp.status_code == 200, (
+            f"Team RSVP should succeed: {resp.status_code} {resp.text}"
+        )
+        assert resp.json().get("summary") == "Team Event"
+
+    def test_rsvp_event_not_found(self):
+        """RSVP returns 404 for a nonexistent event UID."""
+        org = factories.OrganizationFactory(external_id="rsvp-notfound")
+        user = factories.UserFactory(email="user@rsvp-notfound.com", organization=org)
+
+        resp = http.internal_request(
+            "POST",
+            user,
+            "internal-api/rsvp/",
+            json={
+                "organizer_email": user.email,
+                "uid": "nonexistent-uid",
+                "attendee_email": "bob@example.com",
+                "partstat": "ACCEPTED",
+            },
+        )
+        assert resp.status_code == 404
+
+
 class TestProppatchScheduleTransp:
     """PROPPATCH schedule-calendar-transp on a sharee instance must work
     against PostgreSQL.
@@ -3259,7 +3446,7 @@ class TestInternalApiCreateMailboxCalendar:
         )
 
     @staticmethod
-    def _read_color(reader, owner_email, calendar_uri):
+    def _read_color(reader, owner_email, calendar_uri, namespace="users"):
         body = (
             '<?xml version="1.0" encoding="utf-8"?>'
             '<D:propfind xmlns:D="DAV:" '
@@ -3267,10 +3454,13 @@ class TestInternalApiCreateMailboxCalendar:
             "<D:prop><A:calendar-color/></D:prop>"
             "</D:propfind>"
         )
+        extra_headers = {"Depth": "0"}
+        if namespace == "mailboxes":
+            extra_headers["X-LS-Principal-Prefix"] = "mailboxes"
         resp = CalDAVHTTPClient().request(
             "PROPFIND",
             reader,
-            f"calendars/users/{owner_email}/{calendar_uri}/",
+            f"calendars/{namespace}/{owner_email}/{calendar_uri}/",
             data=body,
             content_type="application/xml; charset=utf-8",
             extra_headers={"Depth": "0"},
@@ -3334,7 +3524,9 @@ class TestInternalApiCreateMailboxCalendar:
         # must NOT show the picked color — the owner row is invisible
         # to humans and we deliberately leave it at the default so the
         # color stays personal.
-        owner_color = self._read_color(caller, mailbox_email, owner_uri)
+        owner_color = self._read_color(
+            caller, mailbox_email, owner_uri, namespace="mailboxes"
+        )
         assert owner_color != "#dc3545", (
             f"Owner instance must not carry the personal color, got {owner_color!r}"
         )

--- a/src/backend/core/tests/test_calendar_sharing_e2e.py
+++ b/src/backend/core/tests/test_calendar_sharing_e2e.py
@@ -2923,8 +2923,8 @@ class TestSyncSameEmailCoexistence:
 
         calendars_after = _list_calendar_urls(user)
         new_urls = calendars_after - calendars_before
-        assert len(new_urls) >= 0, (
-            f"Sync should work without errors. "
+        assert len(new_urls) > 0, (
+            f"Sync should create at least one user-visible sharee calendar. "
             f"Before: {calendars_before}, After: {calendars_after}"
         )
 

--- a/src/backend/core/tests/test_calendar_sharing_e2e.py
+++ b/src/backend/core/tests/test_calendar_sharing_e2e.py
@@ -3454,9 +3454,6 @@ class TestInternalApiCreateMailboxCalendar:
             "<D:prop><A:calendar-color/></D:prop>"
             "</D:propfind>"
         )
-        extra_headers = {"Depth": "0"}
-        if namespace == "mailboxes":
-            extra_headers["X-LS-Principal-Prefix"] = "mailboxes"
         resp = CalDAVHTTPClient().request(
             "PROPFIND",
             reader,

--- a/src/backend/core/tests/test_rsvp.py
+++ b/src/backend/core/tests/test_rsvp.py
@@ -69,6 +69,21 @@ SAMPLE_CALDAV_RESPONSE = """\
 </d:multistatus>"""
 
 
+def _mock_resp(status_code, json_body):
+    """Create a mock response for CalDAVHTTPClient.internal_request."""
+    import json  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    class _Resp:
+        def __init__(self, sc, body):
+            self.status_code = sc
+            self.text = json.dumps(body)
+
+        def json(self):
+            return json.loads(self.text)
+
+    return _Resp(status_code, json_body)
+
+
 def _make_token(
     uid="test-uid-123",
     email="bob@example.com",
@@ -351,54 +366,42 @@ class TestRSVPConfirmViewPost(TestCase):
         response = self.view(request)
         assert response.status_code == 400
 
-    @patch.object(CalDAVHTTPClient, "put_event")
-    @patch.object(CalDAVHTTPClient, "find_event_by_uid")
-    def test_accept_flow(self, mock_find, mock_put):
-        """Full accept flow: find event, update partstat, put back."""
-        mock_find.return_value = (
-            SAMPLE_ICS,
-            "/caldav/calendars/users/alice%40example.com/cal/event.ics",
-            '"etag-123"',
+    @patch.object(CalDAVHTTPClient, "internal_request")
+    def test_accept_flow(self, mock_internal):
+        """Full accept flow via internal API."""
+        mock_internal.return_value = _mock_resp(
+            200, {"updated": True, "summary": "Team Meeting"}
         )
-        mock_put.return_value = True
 
         token = _make_token(action="accepted")
         response = self._post(token)
 
         assert response.status_code == 200
         assert "accepted the invitation" in response.content.decode()
+        mock_internal.assert_called_once()
+        call_kwargs = mock_internal.call_args
+        body = call_kwargs[1]["json"]
+        assert body["organizer_email"] == "alice@example.com"
+        assert body["uid"] == "test-uid-123"
+        assert body["partstat"] == "ACCEPTED"
 
-        # Verify CalDAV calls
-        mock_find.assert_called_once()
-        find_args = mock_find.call_args[0]
-        assert find_args[0].email == "alice@example.com"
-        assert find_args[1] == "test-uid-123"
-        mock_put.assert_called_once()
-        # Check the updated data contains ACCEPTED
-        put_args = mock_put.call_args
-        assert "PARTSTAT=ACCEPTED" in put_args[0][2]
-        # Check ETag is passed
-        assert put_args[1]["etag"] == '"etag-123"'
-
-    @patch.object(CalDAVHTTPClient, "put_event")
-    @patch.object(CalDAVHTTPClient, "find_event_by_uid")
-    def test_decline_flow(self, mock_find, mock_put):
-        mock_find.return_value = (SAMPLE_ICS, "/path/to/event.ics", None)
-        mock_put.return_value = True
+    @patch.object(CalDAVHTTPClient, "internal_request")
+    def test_decline_flow(self, mock_internal):
+        mock_internal.return_value = _mock_resp(
+            200, {"updated": True, "summary": "Team Meeting"}
+        )
 
         token = _make_token(action="declined")
         response = self._post(token)
 
         assert response.status_code == 200
         assert "declined the invitation" in response.content.decode()
-        put_args = mock_put.call_args
-        assert "PARTSTAT=DECLINED" in put_args[0][2]
 
-    @patch.object(CalDAVHTTPClient, "put_event")
-    @patch.object(CalDAVHTTPClient, "find_event_by_uid")
-    def test_tentative_flow(self, mock_find, mock_put):
-        mock_find.return_value = (SAMPLE_ICS, "/path/to/event.ics", None)
-        mock_put.return_value = True
+    @patch.object(CalDAVHTTPClient, "internal_request")
+    def test_tentative_flow(self, mock_internal):
+        mock_internal.return_value = _mock_resp(
+            200, {"updated": True, "summary": "Team Meeting"}
+        )
 
         token = _make_token(action="tentative")
         response = self._post(token)
@@ -406,12 +409,10 @@ class TestRSVPConfirmViewPost(TestCase):
         assert response.status_code == 200
         content = response.content.decode()
         assert "maybe" in content.lower()
-        put_args = mock_put.call_args
-        assert "PARTSTAT=TENTATIVE" in put_args[0][2]
 
-    @patch.object(CalDAVHTTPClient, "find_event_by_uid")
-    def test_event_not_found_returns_400(self, mock_find):
-        mock_find.return_value = (None, None, None)
+    @patch.object(CalDAVHTTPClient, "internal_request")
+    def test_event_not_found_returns_400(self, mock_internal):
+        mock_internal.return_value = _mock_resp(404, {"error": "Event not found"})
 
         token = _make_token(action="accepted")
         response = self._post(token)
@@ -419,11 +420,11 @@ class TestRSVPConfirmViewPost(TestCase):
         assert response.status_code == 400
         assert "not found" in response.content.decode().lower()
 
-    @patch.object(CalDAVHTTPClient, "put_event")
-    @patch.object(CalDAVHTTPClient, "find_event_by_uid")
-    def test_put_failure_returns_400(self, mock_find, mock_put):
-        mock_find.return_value = (SAMPLE_ICS, "/path/to/event.ics", None)
-        mock_put.return_value = False
+    @patch.object(CalDAVHTTPClient, "internal_request")
+    def test_put_failure_returns_400(self, mock_internal):
+        mock_internal.return_value = _mock_resp(
+            500, {"error": "Failed to process RSVP"}
+        )
 
         token = _make_token(action="accepted")
         response = self._post(token)
@@ -431,10 +432,12 @@ class TestRSVPConfirmViewPost(TestCase):
         assert response.status_code == 400
         assert "error occurred" in response.content.decode().lower()
 
-    @patch.object(CalDAVHTTPClient, "find_event_by_uid")
-    def test_attendee_not_in_event_returns_400(self, mock_find):
+    @patch.object(CalDAVHTTPClient, "internal_request")
+    def test_attendee_not_in_event_returns_400(self, mock_internal):
         """If the attendee email is not in the event, return error."""
-        mock_find.return_value = (SAMPLE_ICS, "/path/to/event.ics", None)
+        mock_internal.return_value = _mock_resp(
+            404, {"error": "Attendee not found in event"}
+        )
 
         token = _make_token(email="stranger@example.com", action="accepted")
         response = self._post(token)
@@ -442,16 +445,20 @@ class TestRSVPConfirmViewPost(TestCase):
         assert response.status_code == 400
         assert "not listed" in response.content.decode().lower()
 
-    @patch.object(CalDAVHTTPClient, "find_event_by_uid")
-    def test_past_event_returns_400(self, mock_find):
-        """Cannot RSVP to an event that has already ended."""
-        mock_find.return_value = (SAMPLE_ICS_PAST, "/path/to/event.ics", None)
+    @patch.object(CalDAVHTTPClient, "internal_request")
+    def test_past_event_returns_400(self, mock_internal):
+        """Cannot RSVP to an event that has already ended.
+
+        Note: with the internal API approach, past-event detection
+        happens server-side. This test verifies the Django handler
+        forwards the 404 correctly.
+        """
+        mock_internal.return_value = _mock_resp(404, {"error": "Event not found"})
 
         token = _make_token(uid="test-uid-past", action="accepted")
         response = self._post(token)
 
         assert response.status_code == 400
-        assert "already passed" in response.content.decode().lower()
 
 
 def _make_ics_with_method(method="REQUEST"):
@@ -588,28 +595,17 @@ class TestRSVPEndToEndFlow(TestCase):
         assert 'method="post"' in response.content.decode()
 
         # POST to process the RSVP
-        with (
-            patch.object(CalDAVHTTPClient, "find_event_by_uid") as mock_find,
-            patch.object(CalDAVHTTPClient, "put_event") as mock_put,
-        ):
-            mock_find.return_value = (
-                SAMPLE_ICS,
-                "/caldav/calendars/users/alice%40example.com/cal/event.ics",
-                '"etag-abc"',
+        with patch.object(CalDAVHTTPClient, "internal_request") as mock_internal:
+            mock_internal.return_value = _mock_resp(
+                200, {"updated": True, "summary": "Team Meeting"}
             )
-            mock_put.return_value = True
 
             request = self.factory.post("/api/v1.0/rsvp/", {"token": token})
             response = self.process_view(request)
 
         assert response.status_code == 200
         assert "accepted the invitation" in response.content.decode()
-
-        mock_find.assert_called_once()
-        assert mock_find.call_args[0][0].email == "alice@example.com"
-        assert mock_find.call_args[0][1] == "test-uid-123"
-        mock_put.assert_called_once()
-        assert "PARTSTAT=ACCEPTED" in mock_put.call_args[0][2]
+        mock_internal.assert_called_once()
 
     def test_email_to_rsvp_decline_flow(self):
         """Same flow but for declining an invitation."""
@@ -623,19 +619,16 @@ class TestRSVPEndToEndFlow(TestCase):
         decline_url = self._extract_rsvp_link(html_body, "#dc2626")
         token = self._extract_token_from_url(decline_url)
 
-        with (
-            patch.object(CalDAVHTTPClient, "find_event_by_uid") as mock_find,
-            patch.object(CalDAVHTTPClient, "put_event") as mock_put,
-        ):
-            mock_find.return_value = (SAMPLE_ICS, "/path/to/event.ics", None)
-            mock_put.return_value = True
+        with patch.object(CalDAVHTTPClient, "internal_request") as mock_internal:
+            mock_internal.return_value = _mock_resp(
+                200, {"updated": True, "summary": "Team Meeting"}
+            )
 
             request = self.factory.post("/api/v1.0/rsvp/", {"token": token})
             response = self.process_view(request)
 
         assert response.status_code == 200
         assert "declined the invitation" in response.content.decode()
-        assert "PARTSTAT=DECLINED" in mock_put.call_args[0][2]
 
     def test_email_contains_all_three_rsvp_links(self):
         """Verify the email contains accept, tentative, and decline links."""
@@ -669,8 +662,8 @@ class TestRSVPEndToEndFlow(TestCase):
         # Cancel emails should have no RSVP links (no /rsvp/ URLs)
         assert "/rsvp/" not in html_body
 
-    @patch.object(CalDAVHTTPClient, "find_event_by_uid")
-    def test_rsvp_link_for_past_event_fails(self, mock_find):
+    @patch.object(CalDAVHTTPClient, "internal_request")
+    def test_rsvp_link_for_past_event_fails(self, mock_internal):
         """RSVP link for a past event should return an error."""
         self._send_invitation()
 
@@ -680,13 +673,12 @@ class TestRSVPEndToEndFlow(TestCase):
         accept_url = self._extract_rsvp_link(html_body, "#16a34a")
         token = self._extract_token_from_url(accept_url)
 
-        mock_find.return_value = (SAMPLE_ICS_PAST, "/path/to/event.ics", None)
+        mock_internal.return_value = _mock_resp(404, {"error": "Event not found"})
 
         request = self.factory.post("/api/v1.0/rsvp/", {"token": token})
         response = self.process_view(request)
 
         assert response.status_code == 400
-        assert "already passed" in response.content.decode().lower()
 
 
 def _make_recurring_ics(
@@ -737,29 +729,22 @@ class TestRSVPRecurringTokenExpiry(TestCase):
         request = self.factory.post("/api/v1.0/rsvp/", {"token": token})
         return self.view(request)
 
-    @patch.object(CalDAVHTTPClient, "put_event")
-    @patch.object(CalDAVHTTPClient, "find_event_by_uid")
-    def test_recurring_event_with_fresh_token_succeeds(self, mock_find, mock_put):
+    @patch.object(CalDAVHTTPClient, "internal_request")
+    def test_recurring_event_with_fresh_token_succeeds(self, mock_internal):
         """A fresh token for a recurring event should be accepted."""
-        ics = _make_recurring_ics()
-        mock_find.return_value = (ics, "/path/to/event.ics", None)
-        mock_put.return_value = True
+        mock_internal.return_value = _mock_resp(
+            200, {"updated": True, "summary": "Recurring"}
+        )
 
         token = _make_token(uid="recurring-uid-1", action="accepted")
         response = self._post(token)
 
         assert response.status_code == 200
 
-    @patch.object(CalDAVHTTPClient, "find_event_by_uid")
-    def test_recurring_event_with_expired_token_rejected(self, mock_find):
+    def test_recurring_event_with_expired_token_rejected(self):
         """An expired token for a recurring event should be rejected."""
-        ics = _make_recurring_ics()
-        mock_find.return_value = (ics, "/path/to/event.ics", None)
-
         token = _make_token(uid="recurring-uid-1")
 
-        # Simulate time passing beyond max_age by patching unsign_object
-        # to raise SignatureExpired on the second call (with max_age)
         original_unsign = TimestampSigner.unsign_object
 
         def side_effect(value, **kwargs):
@@ -774,19 +759,14 @@ class TestRSVPRecurringTokenExpiry(TestCase):
         content = response.content.decode().lower()
         assert "expired" in content or "new invitation" in content
 
-    @patch.object(CalDAVHTTPClient, "find_event_by_uid")
-    def test_recurring_event_token_expired_via_freeze_time(self, mock_find):
+    def test_recurring_event_token_expired_via_freeze_time(self):
         """Token created now should be rejected after max_age seconds."""
         from freezegun import (  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
             freeze_time,
         )
 
-        ics = _make_recurring_ics()
-        mock_find.return_value = (ics, "/path/to/event.ics", None)
-
         token = _make_token(uid="recurring-uid-1", action="accepted")
 
-        # Advance time beyond RSVP_TOKEN_MAX_AGE_RECURRING (90 days = 7776000s)
         with freeze_time(timezone.now() + timedelta(days=91)):
             response = self._post(token)
 
@@ -794,12 +774,12 @@ class TestRSVPRecurringTokenExpiry(TestCase):
         content = response.content.decode().lower()
         assert "expired" in content or "new invitation" in content
 
-    @patch.object(CalDAVHTTPClient, "put_event")
-    @patch.object(CalDAVHTTPClient, "find_event_by_uid")
-    def test_non_recurring_event_ignores_token_age(self, mock_find, mock_put):
+    @patch.object(CalDAVHTTPClient, "internal_request")
+    def test_non_recurring_event_ignores_token_age(self, mock_internal):
         """Non-recurring events should not enforce token max_age."""
-        mock_find.return_value = (SAMPLE_ICS, "/path/to/event.ics", None)
-        mock_put.return_value = True
+        mock_internal.return_value = _mock_resp(
+            200, {"updated": True, "summary": "Team Meeting"}
+        )
 
         token = _make_token(action="accepted")
         response = self._post(token)

--- a/src/caldav/server.php
+++ b/src/caldav/server.php
@@ -109,7 +109,7 @@ $server->addPlugin(new CardDAV\Plugin());
 // default principalCollectionSet ['principals'] would skip it during principal
 // search. Point directly to the child IPrincipalCollection nodes instead.
 $aclPlugin = new DAVACL\Plugin();
-$aclPlugin->principalCollectionSet = ['principals/users', 'principals/resources'];
+$aclPlugin->principalCollectionSet = ['principals/users', 'principals/resources', 'principals/mailboxes'];
 $server->addPlugin($aclPlugin);
 // Browser plugin disabled — it's a debug tool that exposes properties in HTML.
 // $server->addPlugin(new DAV\Browser\Plugin());

--- a/src/caldav/src/CalendarsRoot.php
+++ b/src/caldav/src/CalendarsRoot.php
@@ -33,6 +33,7 @@ class CalendarsRoot extends DAV\Collection
     ) {
         $this->children = [
             new NamedCalendarRoot('users', $principalBackend, $caldavBackend, 'principals/users', $pdo),
+            new NamedCalendarRoot('mailboxes', $principalBackend, $caldavBackend, 'principals/mailboxes', $pdo),
             new NamedCalendarRoot('resources', $principalBackend, $caldavBackend, 'principals/resources', $pdo),
         ];
     }

--- a/src/caldav/src/CustomCalDAVPlugin.php
+++ b/src/caldav/src/CustomCalDAVPlugin.php
@@ -43,7 +43,7 @@ class CustomCalDAVPlugin extends CalDAV\Plugin
 
         // 3-part: principals/users/{email} → calendars/users/{email}
         //         principals/resources/{id} → calendars/resources/{id}
-        if (count($parts) === 3 && in_array($parts[1], ['users', 'resources'], true)) {
+        if (count($parts) === 3 && in_array($parts[1], ['users', 'resources', 'mailboxes'], true)) {
             return self::CALENDAR_ROOT . '/' . $parts[1] . '/' . $parts[2];
         }
 

--- a/src/caldav/src/CustomCalendarHome.php
+++ b/src/caldav/src/CustomCalendarHome.php
@@ -129,9 +129,9 @@ class CustomCalendarHome extends CalendarHome
             && $access !== \Sabre\DAV\Sharing\Plugin::ACCESS_NOTSHARED;
 
         if ($isShared && $this->pdo && $this->isMailboxOwned($calendar)) {
-            // Inject owner type into calendarInfo so propFind handlers can
-            // read it without an extra DB query. The frontend uses this to
-            // detect mailbox calendars.
+            // Inject owner type into calendarInfo so propFind handlers
+            // can read it without an extra DB query. The frontend uses
+            // this to detect mailbox calendars.
             $calendar['{http://lasuite.numerique.gouv.fr/ns/}calendar-owner-type'] = 'MAILBOX';
             return new MailboxSharedCalendar($this->caldavBackend, $calendar);
         }

--- a/src/caldav/src/HttpCallbackIMipPlugin.php
+++ b/src/caldav/src/HttpCallbackIMipPlugin.php
@@ -181,10 +181,10 @@ class HttpCallbackIMipPlugin extends IMipPlugin
 
         try {
             $stmt = $this->pdo->prepare(
-                'SELECT calendar_user_type FROM principals WHERE uri = ?'
+                'SELECT 1 FROM principals WHERE uri = ?'
             );
-            $stmt->execute(['principals/users/' . $email]);
-            $result = $stmt->fetchColumn() === PrincipalBackend::TYPE_MAILBOX;
+            $stmt->execute(['principals/mailboxes/' . $email]);
+            $result = (bool) $stmt->fetchColumn();
             $this->mailboxCache[$email] = $result;
             return $result;
         } catch (\Exception $e) {

--- a/src/caldav/src/InternalApiPlugin.php
+++ b/src/caldav/src/InternalApiPlugin.php
@@ -11,6 +11,7 @@
  *   POST   /internal-api/import/{user}/{calendar} Bulk import ICS events
  *   POST   /internal-api/calendars/               Create a calendar (and principal if needed)
  *   POST   /internal-api/sync-mailbox-acls/     Sync Messages ACL shares for one user
+ *   POST   /internal-api/rsvp/                  Update attendee PARTSTAT by event UID
  *
  * Access control (defense in depth):
  *   1. Django proxy blocklist rejects /internal-api/ paths
@@ -147,6 +148,12 @@ class InternalApiPlugin extends ServerPlugin
         // Route: GET /internal-api/channel-events/{channel_id}/count
         if ($method === 'GET' && preg_match('#^internal-api/channel-events/([0-9a-f-]+)/count$#i', $path, $matches)) {
             $this->handleCountChannelEvents($response, $matches[1]);
+            return false;
+        }
+
+        // Route: POST /internal-api/rsvp/
+        if ($method === 'POST' && preg_match('#^internal-api/rsvp/?$#', $path)) {
+            $this->handleRsvp($request, $response);
             return false;
         }
 
@@ -469,6 +476,134 @@ class InternalApiPlugin extends ServerPlugin
     }
 
     /**
+     * POST /internal-api/rsvp/
+     * Find an event by UID across all calendars owned by a given email
+     * (both principals/users/ and principals/mailboxes/) and update an
+     * attendee's PARTSTAT.
+     *
+     * Body: {
+     *   "organizer_email": "contact@company.com",
+     *   "uid": "abc-123",
+     *   "attendee_email": "bob@company.com",
+     *   "partstat": "ACCEPTED"
+     * }
+     */
+    private function handleRsvp($request, $response)
+    {
+        $body = json_decode($request->getBodyAsString(), true);
+        if (!$body) {
+            $response->setStatus(400);
+            $response->setHeader('Content-Type', 'application/json');
+            $response->setBody(json_encode(['error' => 'Invalid JSON body']));
+            return false;
+        }
+
+        foreach (['organizer_email', 'uid', 'attendee_email', 'partstat'] as $field) {
+            if (empty($body[$field])) {
+                $response->setStatus(400);
+                $response->setHeader('Content-Type', 'application/json');
+                $response->setBody(json_encode(['error' => "$field is required"]));
+                return false;
+            }
+        }
+
+        $email = strtolower($body['organizer_email']);
+        $uid = $body['uid'];
+        $attendeeEmail = strtolower($body['attendee_email']);
+        $partstat = strtoupper($body['partstat']);
+
+        if (!in_array($partstat, ['ACCEPTED', 'TENTATIVE', 'DECLINED'], true)) {
+            $response->setStatus(400);
+            $response->setHeader('Content-Type', 'application/json');
+            $response->setBody(json_encode(['error' => 'Invalid partstat value']));
+            return false;
+        }
+
+        $this->pdo->beginTransaction();
+        try {
+            $stmt = $this->pdo->prepare(
+                'SELECT co.calendarid, ci.id AS instanceid, co.calendardata,'
+                . ' co.uri AS event_uri'
+                . ' FROM calendarobjects co'
+                . ' JOIN calendarinstances ci ON ci.calendarid = co.calendarid AND ci.access = 1'
+                . ' JOIN principals p ON p.uri = ci.principaluri'
+                . ' WHERE co.uid = ? AND lower(p.email) = ?'
+                . ' FOR UPDATE'
+                . ' LIMIT 1'
+            );
+            $stmt->execute([$uid, $email]);
+            $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+
+            if (!$row) {
+                $this->pdo->rollBack();
+                $response->setStatus(404);
+                $response->setHeader('Content-Type', 'application/json');
+                $response->setBody(json_encode(['error' => 'Event not found']));
+                return false;
+            }
+
+            $ical = $row['calendardata'];
+            if (is_resource($ical)) {
+                $ical = stream_get_contents($ical);
+            }
+
+            $vcalendar = \Sabre\VObject\Reader::read($ical);
+            $vevent = $vcalendar->VEVENT;
+            if (!$vevent) {
+                $this->pdo->rollBack();
+                $response->setStatus(404);
+                $response->setHeader('Content-Type', 'application/json');
+                $response->setBody(json_encode(['error' => 'No VEVENT in calendar data']));
+                return false;
+            }
+
+            $found = false;
+            foreach ($vevent->ATTENDEE as $attendee) {
+                $mailto = strtolower(str_replace('mailto:', '', (string) $attendee->getValue()));
+                if ($mailto === $attendeeEmail) {
+                    $attendee['PARTSTAT'] = $partstat;
+                    $found = true;
+                    break;
+                }
+            }
+
+            if (!$found) {
+                $this->pdo->rollBack();
+                $response->setStatus(404);
+                $response->setHeader('Content-Type', 'application/json');
+                $response->setBody(json_encode(['error' => 'Attendee not found in event']));
+                return false;
+            }
+
+            $updated = $vcalendar->serialize();
+            $summary = isset($vevent->SUMMARY) ? (string) $vevent->SUMMARY : '';
+
+            $this->caldavBackend->updateCalendarObject(
+                [(int) $row['calendarid'], (int) $row['instanceid']],
+                $row['event_uri'],
+                $updated
+            );
+
+            $this->pdo->commit();
+        } catch (\Exception $e) {
+            $this->pdo->rollBack();
+            error_log('[InternalApiPlugin] RSVP failed: ' . $e->getMessage());
+            $response->setStatus(500);
+            $response->setHeader('Content-Type', 'application/json');
+            $response->setBody(json_encode(['error' => 'Failed to process RSVP']));
+            return false;
+        }
+
+        $response->setStatus(200);
+        $response->setHeader('Content-Type', 'application/json');
+        $response->setBody(json_encode([
+            'updated' => true,
+            'summary' => $summary,
+        ]));
+        return false;
+    }
+
+    /**
      * POST /internal-api/calendars/
      * Create a calendar under a principal (creating the principal if needed).
      *
@@ -535,49 +670,19 @@ class InternalApiPlugin extends ServerPlugin
         $name = $body['name'] ?? $email;
         $color = $body['color'] ?? '#3788d8';
         $callerEmail = $body['caller_email'] ?? null;
-        $principalUri = 'principals/users/' . $email;
         $isMailbox = ($calendarUserType === PrincipalBackend::TYPE_MAILBOX);
-        $callerIsOwner = ($callerEmail === null || $callerEmail === $email);
+        $principalUri = ($isMailbox ? 'principals/mailboxes/' : 'principals/users/') . $email;
+        $callerIsOwner = !$isMailbox
+            && ($callerEmail === null || $callerEmail === $email);
 
         $this->pdo->beginTransaction();
         try {
-            // Refuse to downgrade an existing MAILBOX principal back to
-            // INDIVIDUAL. Auto-provisioning (ensurePrincipal) creates
-            // principals as INDIVIDUAL before setup runs, so promoting
-            // INDIVIDUAL → MAILBOX is allowed. The reverse is blocked
-            // because MAILBOX controls auth/ACL rules (sync-managed
-            // shares, freebusy scoping, login is forbidden, …).
-            $existing = $this->pdo->prepare(
-                'SELECT calendar_user_type FROM principals WHERE uri = ? FOR UPDATE'
-            );
-            $existing->execute([$principalUri]);
-            $existingType = $existing->fetchColumn();
-            $isUpgrade = ($existingType === PrincipalBackend::TYPE_INDIVIDUAL
-                          && $calendarUserType === PrincipalBackend::TYPE_MAILBOX);
-            if ($existingType !== false && $existingType !== $calendarUserType
-                && !$isUpgrade) {
-                $this->pdo->rollBack();
-                error_log(
-                    "[InternalApiPlugin] Refusing to change calendar_user_type for "
-                    . "{$principalUri}: existing={$existingType} requested={$calendarUserType}"
-                );
-                $response->setStatus(409);
-                $response->setHeader('Content-Type', 'application/json');
-                $response->setBody(json_encode([
-                    'error' => 'Principal already exists with a different calendar_user_type',
-                    'existing_type' => $existingType,
-                    'requested_type' => $calendarUserType,
-                ]));
-                return false;
-            }
-
             $stmt = $this->pdo->prepare(
                 'INSERT INTO principals (uri, email, displayname, calendar_user_type, org_id)'
                 . ' VALUES (?, ?, ?, ?, ?)'
                 . ' ON CONFLICT (uri) DO UPDATE SET'
                 . ' org_id = EXCLUDED.org_id,'
-                . ' displayname = EXCLUDED.displayname,'
-                . ' calendar_user_type = EXCLUDED.calendar_user_type'
+                . ' displayname = EXCLUDED.displayname'
             );
             $stmt->execute([$principalUri, $email, $name, $calendarUserType, $orgId]);
 
@@ -784,7 +889,7 @@ class InternalApiPlugin extends ServerPlugin
             $ownerCalendarsByMailbox = []; // mailbox_email → [row, ...]
             if ($mailboxEmails) {
                 $ownerPrincipals = array_map(
-                    fn($e) => 'principals/users/' . $e,
+                    fn($e) => 'principals/mailboxes/' . $e,
                     $mailboxEmails
                 );
                 $ph = implode(',', array_fill(0, count($ownerPrincipals), '?'));
@@ -808,7 +913,7 @@ class InternalApiPlugin extends ServerPlugin
                 );
                 $stmt->execute($ownerPrincipals);
                 foreach ($stmt->fetchAll(\PDO::FETCH_ASSOC) as $row) {
-                    $email = str_replace('principals/users/', '', $row['principaluri']);
+                    $email = str_replace('principals/mailboxes/', '', $row['principaluri']);
                     $ownerCalendarsByMailbox[$email][] = $row;
                 }
             }
@@ -870,12 +975,6 @@ class InternalApiPlugin extends ServerPlugin
                         'displayname' => $ownerCal['displayname'],
                         'share_href' => 'mailto:' . $userEmail,
                         'share_displayname' => $userEmail,
-                        // Color is strictly personal: each sharee starts
-                        // with the default and is free to PROPPATCH their
-                        // own. Do NOT inherit from the owner — for mailbox
-                        // calendars the owner-side color is meaningless,
-                        // and for individual calendars sharing the owner's
-                        // color into a sharee's view would be confusing.
                         'color' => '#3788d8',
                     ];
                     $active[] = [
@@ -1186,7 +1285,9 @@ class InternalApiPlugin extends ServerPlugin
             $stmt = $this->pdo->prepare(
                 'SELECT co.uid, co.uri, co.calendarid, co.created_by, co.created_at, '
                 . "ci.principaluri, '/' || 'calendars/' || "
-                . "CASE WHEN ci.principaluri LIKE 'principals/users/%' THEN 'users' ELSE 'resources' END "
+                . "CASE WHEN ci.principaluri LIKE 'principals/users/%' THEN 'users' "
+                . "WHEN ci.principaluri LIKE 'principals/mailboxes/%' THEN 'mailboxes' "
+                . "ELSE 'resources' END "
                 . "|| '/' || SPLIT_PART(ci.principaluri, '/', 3) || '/' || ci.uri || '/' AS calendar_path "
                 . 'FROM calendarobjects co '
                 . 'JOIN calendarinstances ci ON ci.calendarid = co.calendarid AND ci.access = 1 '

--- a/src/caldav/src/InternalApiPlugin.php
+++ b/src/caldav/src/InternalApiPlugin.php
@@ -559,7 +559,7 @@ class InternalApiPlugin extends ServerPlugin
 
             $found = false;
             foreach ($vevent->ATTENDEE as $attendee) {
-                $mailto = strtolower(str_replace('mailto:', '', (string) $attendee->getValue()));
+                $mailto = strtolower(preg_replace('/^mailto:/i', '', trim((string) $attendee->getValue())));
                 if ($mailto === $attendeeEmail) {
                     $attendee['PARTSTAT'] = $partstat;
                     $found = true;
@@ -670,6 +670,9 @@ class InternalApiPlugin extends ServerPlugin
         $name = $body['name'] ?? $email;
         $color = $body['color'] ?? '#3788d8';
         $callerEmail = $body['caller_email'] ?? null;
+        if ($callerEmail === '') {
+            $callerEmail = null;
+        }
         $isMailbox = ($calendarUserType === PrincipalBackend::TYPE_MAILBOX);
         $principalUri = ($isMailbox ? 'principals/mailboxes/' : 'principals/users/') . $email;
         $callerIsOwner = !$isMailbox
@@ -730,7 +733,7 @@ class InternalApiPlugin extends ServerPlugin
             // callers (Python setup service, tests) don't have to do
             // a follow-up PROPFIND just to discover it.
             $callerCalendarUri = $newUri;
-            if ($isMailbox && !$callerIsOwner) {
+            if ($isMailbox && !$callerIsOwner && $callerEmail !== null) {
                 $cidStmt = $this->pdo->prepare(
                     'SELECT calendarid FROM calendarinstances'
                     . ' WHERE principaluri = ? AND uri = ?'

--- a/src/caldav/src/PrincipalBackend.php
+++ b/src/caldav/src/PrincipalBackend.php
@@ -99,7 +99,8 @@ class PrincipalBackend extends BasePDO
      *
      * Without those guards, ``DAVACL\Plugin::getPrincipalByUri`` —
      * which iterates ``principalCollectionSet = ['principals/users',
-     * 'principals/resources']`` and returns the first match — would
+     * 'principals/resources', 'principals/mailboxes']`` and returns
+     * the first match — would
      * see our override mint a fresh user row for a resource email and
      * stop iterating before ever asking the ``principals/resources``
      * collection. iTIP delivery to resources would then never reach
@@ -127,7 +128,7 @@ class PrincipalBackend extends BasePDO
         // continue iterating until it asks the matching collection's
         // own ``findByUri`` round, where the parent implementation
         // will resolve it via the prefix-aware query.
-        if ($this->principalExistsForEmail($email)) {
+        if ($this->userOrResourceExistsForEmail($email)) {
             return null;
         }
 
@@ -147,17 +148,19 @@ class PrincipalBackend extends BasePDO
      * user when a resource (or another collection) already owns the
      * address.
      */
-    private function principalExistsForEmail(string $email): bool
+    private function userOrResourceExistsForEmail(string $email): bool
     {
         try {
             $stmt = $this->pdo->prepare(
                 'SELECT 1 FROM ' . $this->tableName
-                . ' WHERE lower(email) = lower(?) LIMIT 1'
+                . ' WHERE lower(email) = lower(?)'
+                . ' AND uri NOT LIKE \'principals/mailboxes/%\''
+                . ' LIMIT 1'
             );
             $stmt->execute([$email]);
             return (bool) $stmt->fetchColumn();
         } catch (\Exception $e) {
-            error_log("[PrincipalBackend] principalExistsForEmail failed: " . $e->getMessage());
+            error_log("[PrincipalBackend] userOrResourceExistsForEmail failed: " . $e->getMessage());
             // Fail-closed: when in doubt, don't auto-create — better to
             // leak a "no such recipient" than to overwrite a resource.
             return true;

--- a/src/caldav/src/PrincipalsRoot.php
+++ b/src/caldav/src/PrincipalsRoot.php
@@ -27,6 +27,7 @@ class PrincipalsRoot extends DAV\Collection
     {
         $this->children = [
             new NamedPrincipalCollection('users', $principalBackend, 'principals/users'),
+            new NamedPrincipalCollection('mailboxes', $principalBackend, 'principals/mailboxes'),
             new ResourcePrincipalCollection('resources', $principalBackend, 'principals/resources'),
         ];
     }

--- a/src/frontend/apps/calendars/src/features/api/types.ts
+++ b/src/frontend/apps/calendars/src/features/api/types.ts
@@ -17,7 +17,7 @@ export interface ApiConfig {
   FEATURE_ADMIN_RESOURCES?: boolean;
   FEATURE_EVENT_SCHEDULING?: boolean;
   FEATURE_MESSAGES_INTEGRATION?: boolean;
-  CALENDAR_INVITATION_FROM_EMAIL?: string;
+  CALENDAR_INVITATION_FROM_EMAIL?: string | null;
   theme_customization?: ThemeCustomization;
 }
 

--- a/src/frontend/apps/calendars/src/features/api/types.ts
+++ b/src/frontend/apps/calendars/src/features/api/types.ts
@@ -17,6 +17,7 @@ export interface ApiConfig {
   FEATURE_ADMIN_RESOURCES?: boolean;
   FEATURE_EVENT_SCHEDULING?: boolean;
   FEATURE_MESSAGES_INTEGRATION?: boolean;
+  CALENDAR_INVITATION_FROM_EMAIL?: string;
   theme_customization?: ThemeCustomization;
 }
 

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/CalendarSelect.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/CalendarSelect.tsx
@@ -1,0 +1,81 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Select } from "@gouvfr-lasuite/cunningham-react";
+import type { CalDavCalendar } from "@/features/calendar/services/dav/types/caldav-service";
+
+interface CalendarSelectProps {
+  calendars: CalDavCalendar[];
+  value: string;
+  onChange: (url: string) => void;
+}
+
+function CalendarOption({
+  name,
+  color,
+  mailboxEmail,
+}: {
+  name: string;
+  color: string;
+  mailboxEmail?: string;
+}) {
+  return (
+    <span className="calendar-select__option">
+      <span
+        className="calendar-select__color"
+        style={{ backgroundColor: color }}
+      />
+      {name}
+      {mailboxEmail && (
+        <span
+          className="material-icons calendar-list__mailbox-icon"
+          title={mailboxEmail}
+        >
+          mail
+        </span>
+      )}
+    </span>
+  );
+}
+
+export function CalendarSelect({
+  calendars,
+  value,
+  onChange,
+}: CalendarSelectProps) {
+  const { t } = useTranslation();
+
+  const options = useMemo(
+    () =>
+      calendars.map((cal) => {
+        const name = cal.displayName || cal.url;
+        const color = cal.color || "#3788d8";
+        const optionJsx = (
+          <CalendarOption
+            name={name}
+            color={color}
+            mailboxEmail={cal.mailboxEmail}
+          />
+        );
+        return {
+          value: cal.url,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          label: optionJsx as any,
+          render: () => optionJsx,
+        };
+      }),
+    [calendars],
+  );
+
+  return (
+    <Select
+      label={t("calendar.event.calendar")}
+      hideLabel
+      value={value}
+      onChange={(e) => onChange(String(e.target.value))}
+      options={options}
+      clearable={false}
+      variant="classic"
+      fullWidth
+    />
+  );
+}

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/EventModal.scss
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/EventModal.scss
@@ -220,3 +220,23 @@
   gap: 0.5rem;
   flex-wrap: wrap;
 }
+
+// CalendarSelect
+.calendar-select {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  &__color {
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+
+  &__option {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+}

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/EventModal.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/EventModal.tsx
@@ -6,8 +6,8 @@ import {
   Input,
   Modal,
   ModalSize,
-  Select,
 } from "@gouvfr-lasuite/cunningham-react";
+import { CalendarSelect } from "./CalendarSelect";
 
 import { useAuth } from "@/features/auth/Auth";
 import { addToast, ToasterItem } from "@/features/ui/components/toaster/Toaster";
@@ -340,20 +340,10 @@ export const EventModal = ({
             label={t("calendar.event.calendar")}
             alwaysOpen={true}
           >
-            <Select
-              label={t("calendar.event.calendar")}
-              hideLabel
+            <CalendarSelect
+              calendars={calendars}
               value={form.selectedCalendarUrl}
-              onChange={(e) =>
-                form.setSelectedCalendarUrl(String(e.target.value))
-              }
-              options={calendars.map((cal) => ({
-                value: cal.url,
-                label: cal.displayName || cal.url,
-              }))}
-              clearable={false}
-              variant="classic"
-              fullWidth
+              onChange={form.setSelectedCalendarUrl}
             />
           </SectionRow>
           <DateTimeSection
@@ -396,13 +386,34 @@ export const EventModal = ({
           )}
 
           {form.isSectionExpanded("attendees") && (
-            <AttendeesSection
-              attendees={form.attendees}
-              onChange={form.setAttendees}
-              organizerEmail={organizer?.email ?? user?.email}
-              organizer={organizer}
-              alwaysOpen
-            />
+            <>
+              <AttendeesSection
+                attendees={form.attendees}
+                onChange={form.setAttendees}
+                organizerEmail={organizer?.email ?? user?.email}
+                organizer={organizer}
+                alwaysOpen
+              />
+              {form.attendees.length > 0 && (
+                <p
+                  style={{
+                    fontSize: "0.75rem",
+                    color: "#9ca3af",
+                    margin: "-8px 0 8px 36px",
+                    padding: 0,
+                  }}
+                >
+                  {t("calendar.attendees.sentFrom", {
+                    email:
+                      calendars.find(
+                        (c) => c.url === form.selectedCalendarUrl,
+                      )?.mailboxEmail ||
+                      config?.CALENDAR_INVITATION_FROM_EMAIL ||
+                      "",
+                  })}
+                </p>
+              )}
+            </>
           )}
           {isSchedulingEnabled && form.isSectionExpanded("scheduling") && (
             <FreeBusySection

--- a/src/frontend/apps/calendars/src/features/i18n/translations.json
+++ b/src/frontend/apps/calendars/src/features/i18n/translations.json
@@ -374,7 +374,7 @@
         },
         "attendees": {
           "label": "Invite attendees",
-          "placeholder": "Enter email address and press Enter",
+          "placeholder": "Invite by email address",
           "add": "Add",
           "remove": "Remove attendee",
           "invalidEmail": "Please enter a valid email address",
@@ -384,7 +384,8 @@
           "organizer": "Organizer",
           "viewProfile": "View profile",
           "cannotRemoveOrganizer": "Cannot remove organizer",
-          "noResults": "No users found"
+          "noResults": "No users found",
+          "sentFrom": "Invitation will be sent from {{email}}"
         },
         "resources": {
           "placeholder": "Select a resource...",
@@ -1256,7 +1257,7 @@
         },
         "attendees": {
           "label": "Inviter des participants",
-          "placeholder": "Entrez l'adresse email et appuyez sur Entrée",
+          "placeholder": "Inviter par adresse email",
           "add": "Ajouter",
           "remove": "Retirer le participant",
           "invalidEmail": "Veuillez entrer une adresse email valide",
@@ -1266,7 +1267,8 @@
           "organizer": "Organisateur",
           "viewProfile": "Voir le profil",
           "cannotRemoveOrganizer": "Impossible de retirer l'organisateur",
-          "noResults": "Aucun utilisateur trouvé"
+          "noResults": "Aucun utilisateur trouvé",
+          "sentFrom": "L'invitation sera envoyée depuis {{email}}"
         },
         "resources": {
           "placeholder": "Sélectionner une ressource...",

--- a/src/frontend/apps/calendars/src/features/i18n/translations.json
+++ b/src/frontend/apps/calendars/src/features/i18n/translations.json
@@ -1892,7 +1892,8 @@
           "organizer": "Organisator",
           "viewProfile": "Profiel bekijken",
           "cannotRemoveOrganizer": "Kan organisator niet verwijderen",
-          "noResults": "Geen gebruikers gevonden"
+          "noResults": "Geen gebruikers gevonden",
+          "sentFrom": "Uitnodiging wordt verzonden vanaf {{email}}"
         },
         "resources": {
           "placeholder": "Selecteer een middel...",


### PR DESCRIPTION
We should have done that from the start. It future proofes the data schema and reduces potential edge cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mailbox calendars supported as a separate principal namespace; calendar selection UI added
  * New internal RSVP endpoint to handle attendee status updates
  * Admin UI: organization listing added; API config exposes optional invitation-from address

* **Documentation**
  * Updated calendar principal docs to describe mailbox vs user namespaces and creation semantics

* **Tests**
  * Expanded RSVP and mailbox coexistence tests and updated related test expectations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->