### PR TITLE
🐛(channels) change format of caldav channel password + fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ migrate: ## run django migrations
 
 superuser: ## Create an admin superuser with password "admin"
 	@echo "$(BOLD)Creating a Django superuser$(RESET)"
-	@$(MANAGE) createsuperuser --email admin@example.com --password admin
+	@$(MANAGE) createsuperuser --email admin@admin.local --password admin
 .PHONY: superuser
 
 shell-back: ## open a shell in the backend container

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Calendars empowers teams to manage events and schedules while maintaining full c
 - 🏢 Create workspaces to organize team collaboration
 
 ### Self-host
-*   🚀 Easy to install, scalable and secure calendar solution
+*  🚀 Easy to install, scalable and secure calendar solution
 
 ## Getting started 🔧
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -196,13 +196,12 @@ services:
       postgresql:
         condition: service_healthy
     healthcheck:
-      # Apache serves SabreDAV at /caldav/*; hitting /server.php yields a
-      # routing error (5xx), but what we care about is that Apache is up
-      # and accepting connections. Use curl without -f and check it gets
-      # a response at all — any HTTP reply means the server is ready.
+      # Probe the actual SabreDAV base URI. Unauthenticated, it returns
+      # 401 — a clean "server is up and routing" signal that doesn't
+      # spam the Apache error log. Any HTTP reply counts as healthy.
       test:
         - "CMD-SHELL"
-        - "curl -s -o /dev/null http://localhost/server.php || exit 1"
+        - "curl -s -o /dev/null http://localhost/caldav/ || exit 1"
       interval: 2s
       timeout: 3s
       retries: 30

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -17,11 +17,13 @@ CalDAV authentication mechanism. This means any CalDAV client library
 box:
 
 ```http
-Authorization: Basic base64(<user_email>:<channel_id>:<channel_token>)
+Authorization: Basic base64(<user_email>:<channel_id><channel_token>)
 ```
 
 - **username** = user email (enables standard CalDAV principal discovery)
-- **password** = `channel_id:channel_token`
+- **password** = `<channel_id><channel_token>` — the base64url-encoded
+  channel id (fixed 22 chars) immediately followed by the token, with
+  **no separator**.
 
 Using the user's email as the Basic Auth username means CalDAV principal
 discovery works naturally: the server returns the correct
@@ -73,7 +75,7 @@ import caldav
 client = caldav.DAVClient(
     url="https://calendar.example.com/caldav/",
     username=user_email,
-    password=f"{CHANNEL_ID}:{CHANNEL_TOKEN}",
+    password=f"{CHANNEL_ID}{CHANNEL_TOKEN}",
 )
 # Standard CalDAV principal discovery works
 principal = client.principal()

--- a/env.d/development/caldav-test.defaults
+++ b/env.d/development/caldav-test.defaults
@@ -3,6 +3,7 @@ PGPORT=5432
 PGDATABASE=caldav_test
 PGUSER=pgroot
 PGPASSWORD=pass
+CALDAV_DB_SCHEMA=sabre
 CALDAV_BASE_URI=/caldav/
 CALDAV_INBOUND_API_KEY=changeme-inbound-in-production
 CALDAV_OUTBOUND_API_KEY=changeme-outbound-in-production

--- a/env.d/development/caldav.defaults
+++ b/env.d/development/caldav.defaults
@@ -3,6 +3,8 @@ PGPORT=5432
 PGDATABASE=calendars
 PGUSER=pgroot
 PGPASSWORD=pass
+# Postgres schema that hosts all sabre/dav tables. Defaults to "public".
+CALDAV_DB_SCHEMA=sabre
 CALDAV_BASE_URI=/caldav/
 CALDAV_INBOUND_API_KEY=changeme-inbound-in-production
 CALDAV_OUTBOUND_API_KEY=changeme-outbound-in-production

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -34,6 +34,7 @@ class UserAdmin(auth_admin.UserAdmin):
                     "language",
                     "timezone",
                     "organization",
+                    "claims",
                 )
             },
         ),
@@ -88,6 +89,7 @@ class UserAdmin(auth_admin.UserAdmin):
         "sub",
         "email",
         "full_name",
+        "claims",
         "created_at",
         "updated_at",
     )

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -1,7 +1,10 @@
 """Admin classes and registrations for core app."""
 
+import secrets
+
 from django.contrib import admin
 from django.contrib.auth import admin as auth_admin
+from django.template.response import TemplateResponse
 
 from . import models
 
@@ -30,6 +33,7 @@ class UserAdmin(auth_admin.UserAdmin):
                     "full_name",
                     "language",
                     "timezone",
+                    "organization",
                 )
             },
         ),
@@ -88,6 +92,7 @@ class UserAdmin(auth_admin.UserAdmin):
         "updated_at",
     )
     search_fields = ("id", "sub", "admin_email", "email", "full_name")
+    raw_id_fields = ("organization",)
 
 
 @admin.register(models.Organization)
@@ -116,5 +121,42 @@ class ChannelAdmin(admin.ModelAdmin):
     )
     list_filter = ("type", "is_active")
     search_fields = ("name", "user__email", "caldav_path")
+    exclude = ("encrypted_settings",)
     readonly_fields = ("id", "created_at", "updated_at", "last_used_at")
     raw_id_fields = ("user", "organization")
+    actions = ("regenerate_tokens",)
+
+    @admin.action(description="Regenerate token for selected channels")
+    def regenerate_tokens(self, request, queryset):
+        """Regenerate the token for each selected channel.
+
+        New tokens are rendered directly on a success page (not via the
+        messages framework, which would persist them in the session cookie).
+        They cannot be retrieved afterwards since ``encrypted_settings`` is
+        not exposed in the admin.
+
+        For CalDAV channels the full HTTP Basic Auth password
+        (``base64url(channel_id):token``) is shown alongside the raw token.
+        """
+        results = []
+        for channel in queryset:
+            token = secrets.token_urlsafe(16)
+            channel.encrypted_settings = {
+                **channel.encrypted_settings,
+                "token": token,
+            }
+            channel.save(update_fields=["encrypted_settings", "updated_at"])
+            password = None
+            if channel.type == "caldav":
+                short_id = models.uuid_to_urlsafe(channel.pk)
+                password = f"{short_id}:{token}"
+            results.append((channel, token, password))
+
+        context = {
+            **self.admin_site.each_context(request),
+            "title": "Regenerated channel tokens",
+            "results": results,
+        }
+        return TemplateResponse(
+            request, "admin/core/channel/regenerated_tokens.html", context
+        )

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -136,7 +136,8 @@ class ChannelAdmin(admin.ModelAdmin):
         not exposed in the admin.
 
         For CalDAV channels the full HTTP Basic Auth password
-        (``base64url(channel_id):token``) is shown alongside the raw token.
+        (``base64url(channel_id)`` concatenated with ``token``) is shown
+        alongside the raw token.
         """
         results = []
         for channel in queryset:
@@ -149,7 +150,7 @@ class ChannelAdmin(admin.ModelAdmin):
             password = None
             if channel.type == "caldav":
                 short_id = models.uuid_to_urlsafe(channel.pk)
-                password = f"{short_id}:{token}"
+                password = f"{short_id}{token}"
             results.append((channel, token, password))
 
         context = {

--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -57,7 +57,7 @@ class UserAdmin(auth_admin.UserAdmin):
             None,
             {
                 "classes": ("wide",),
-                "fields": ("email", "password1", "password2"),
+                "fields": ("email", "organization", "password1", "password2"),
             },
         ),
     )

--- a/src/backend/core/api/serializers.py
+++ b/src/backend/core/api/serializers.py
@@ -227,9 +227,13 @@ class ChannelWithTokenSerializer(ChannelSerializer):
         fields = [*ChannelSerializer.Meta.fields, "token", "password"]
 
     def get_password(self, obj) -> str:
-        """Build the CalDAV password: base64url(channel_id):token."""
+        """Build the CalDAV password: base64url(channel_id) followed by token.
+
+        The short_id is a fixed-length (22-char) base64url-encoded UUID so
+        the concatenation can be parsed by slicing.
+        """
         short_id = uuid_to_urlsafe(obj.pk)
-        return f"{short_id}:{obj.token}"
+        return f"{short_id}{obj.token}"
 
 
 class ChannelUpdateSerializer(serializers.Serializer):  # pylint: disable=abstract-method

--- a/src/backend/core/api/viewsets_caldav.py
+++ b/src/backend/core/api/viewsets_caldav.py
@@ -47,18 +47,24 @@ class CalDAVProxyView(View):
 
     External services authenticate via HTTP Basic Auth where the
     username is the user's email (enabling standard CalDAV principal
-    discovery) and the password looks like ``channel_id:channel_token``.
-    This is standard CalDAV auth that works with any CalDAV client library.
+    discovery) and the password is ``channel_id`` immediately followed
+    by ``channel_token`` (no separator; the channel_id is a fixed-length
+    22-char base64url UUID). This is standard CalDAV auth that works
+    with any CalDAV client library.
     """
+
+    # Length of a base64url-encoded UUID (16 bytes) without padding.
+    _CHANNEL_ID_LEN = 22
 
     @staticmethod
     def _authenticate_basic_auth(request):
         """Authenticate via HTTP Basic Auth.
 
-        Format: ``user_email:channel_id:token``
+        Basic-auth payload: ``user_email:<channel_id><token>``
 
         The username is the user's email (enabling standard CalDAV
-        principal discovery). The password looks like ``channel_id:token``.
+        principal discovery). The password is the 22-char base64url
+        channel id concatenated with the raw token.
 
         Returns (channel, email) on success, (None, None) on failure.
         """
@@ -69,9 +75,11 @@ class CalDAVProxyView(View):
         try:
             decoded = base64.b64decode(auth_header[6:]).decode("utf-8")
             email, credentials = decoded.split(":", 1)
-            channel_id, token = credentials.split(":", 1)
         except (ValueError, UnicodeDecodeError, binascii.Error):
             return None, None
+
+        channel_id = credentials[: CalDAVProxyView._CHANNEL_ID_LEN]
+        token = credentials[CalDAVProxyView._CHANNEL_ID_LEN :]
 
         if not email or not channel_id or not token:
             return None, None
@@ -79,7 +87,7 @@ class CalDAVProxyView(View):
         try:
             channel_pk = urlsafe_to_uuid(channel_id)
         except (ValueError, binascii.Error):
-            channel_pk = channel_id
+            return None, None
 
         try:
             channel = Channel.objects.select_related("user", "user__organization").get(

--- a/src/backend/core/api/viewsets_caldav.py
+++ b/src/backend/core/api/viewsets_caldav.py
@@ -86,14 +86,10 @@ class CalDAVProxyView(View):
 
         try:
             channel_pk = urlsafe_to_uuid(channel_id)
-        except (ValueError, binascii.Error):
-            return None, None
-
-        try:
             channel = Channel.objects.select_related("user", "user__organization").get(
                 pk=channel_pk, is_active=True, type="caldav"
             )
-        except (ValueError, ValidationError, Channel.DoesNotExist):
+        except (ValueError, ValidationError, binascii.Error, Channel.DoesNotExist):
             return None, None
 
         if not channel.verify_token(token):

--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -74,14 +74,23 @@ class OIDCAuthenticationBackend(LaSuiteOIDCAuthenticationBackend):
     """
 
     def get_extra_claims(self, user_info):
-        """Return extra claims from user_info."""
+        """Return extra claims from user_info.
+
+        The org claim (``OIDC_USERINFO_ORGANIZATION_CLAIM``) is surfaced at
+        the top level so ``_resolve_org_external_id`` can read it directly,
+        independently of whether it's also listed in ``OIDC_STORE_CLAIMS``.
+        """
         claims_to_store = {
             claim: user_info.get(claim) for claim in settings.OIDC_STORE_CLAIMS
         }
-        return {
+        extra = {
             "full_name": self.compute_full_name(user_info),
             "claims": claims_to_store,
         }
+        org_claim = settings.OIDC_USERINFO_ORGANIZATION_CLAIM
+        if org_claim:
+            extra[org_claim] = user_info.get(org_claim)
+        return extra
 
     def get_existing_user(self, sub, email):
         """Fetch existing user by sub or email."""
@@ -94,18 +103,21 @@ class OIDCAuthenticationBackend(LaSuiteOIDCAuthenticationBackend):
         """Create a new user, resolving their organization first.
 
         Organization is NOT NULL, so we must resolve it before the initial save.
+        The org claim is surfaced at the top level of ``claims`` by
+        ``get_extra_claims`` so we can read it here. It must be popped before
+        delegating to ``super().create_user``, which forwards unknown top-level
+        keys as ``User(**claims)`` kwargs and would otherwise error.
         """
-        logger.warning(
-            "OIDC create_user claims (keys=%s): %s",
-            sorted(claims.keys()) if isinstance(claims, dict) else type(claims),
-            claims,
-        )
         external_id = _resolve_org_external_id(claims)
         if not external_id:
             raise SuspiciousOperation(
                 "Cannot create user without an organization "
                 "(no org claim and no email domain)"
             )
+
+        org_claim = settings.OIDC_USERINFO_ORGANIZATION_CLAIM
+        if org_claim:
+            claims.pop(org_claim, None)
 
         org, _ = Organization.objects.get_or_create(
             external_id=external_id,

--- a/src/backend/core/authentication/backends.py
+++ b/src/backend/core/authentication/backends.py
@@ -95,6 +95,11 @@ class OIDCAuthenticationBackend(LaSuiteOIDCAuthenticationBackend):
 
         Organization is NOT NULL, so we must resolve it before the initial save.
         """
+        logger.warning(
+            "OIDC create_user claims (keys=%s): %s",
+            sorted(claims.keys()) if isinstance(claims, dict) else type(claims),
+            claims,
+        )
         external_id = _resolve_org_external_id(claims)
         if not external_id:
             raise SuspiciousOperation(

--- a/src/backend/core/models.py
+++ b/src/backend/core/models.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.contrib.auth import models as auth_models
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.core import mail, validators
+from django.core.exceptions import ValidationError
 from django.db import models
 
 from encrypted_fields.fields import EncryptedJSONField
@@ -285,7 +286,7 @@ class Channel(BaseModel):
 
     Follows the same pattern as the Messages Channel model. Allows external
     services (e.g. Messages) to access CalDAV on behalf of a user via
-    HTTP Basic Auth (channel_id:token).
+    HTTP Basic Auth (channel_id followed by token, no separator).
 
     Configuration is split between ``settings`` (public, non-sensitive) and
     ``encrypted_settings`` (sensitive data like tokens). Scopes for
@@ -391,8 +392,6 @@ class Channel(BaseModel):
 
     def clean(self):
         """Validate scope_level invariants and scopes."""
-        from django.core.exceptions import ValidationError  # noqa: PLC0415, I001  # pylint: disable=C0415
-
         sl = self.scope_level
         if sl == ChannelScopeLevel.USER and not self.user_id:
             raise ValidationError("User is required for scope_level='user'.")

--- a/src/backend/core/templates/admin/core/channel/regenerated_tokens.html
+++ b/src/backend/core/templates/admin/core/channel/regenerated_tokens.html
@@ -1,0 +1,46 @@
+{% extends "admin/base_site.html" %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">Home</a>
+  &rsaquo; <a href="{% url 'admin:app_list' app_label='core' %}">Core</a>
+  &rsaquo; <a href="{% url 'admin:core_channel_changelist' %}">Channels</a>
+  &rsaquo; Regenerated tokens
+</div>
+{% endblock %}
+
+{% block content %}
+<p>
+  The new tokens below are shown <strong>only once</strong>. Copy them now —
+  they cannot be retrieved afterwards.
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Channel</th>
+      <th>Type</th>
+      <th>New token</th>
+      <th>CalDAV password</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for channel, token, password in results %}
+    <tr>
+      <td>
+        <a href="{% url 'admin:core_channel_change' channel.pk %}">{{ channel.name }}</a>
+      </td>
+      <td>{{ channel.type }}</td>
+      <td><code>{{ token }}</code></td>
+      <td>
+        {% if password %}<code>{{ password }}</code>{% else %}&mdash;{% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<p>
+  <a href="{% url 'admin:core_channel_changelist' %}" class="button">Back to channels</a>
+</p>
+{% endblock %}

--- a/src/backend/core/tests/authentication/test_backends.py
+++ b/src/backend/core/tests/authentication/test_backends.py
@@ -567,3 +567,41 @@ def test_authentication_store_claims_existing_user(monkeypatch):
     assert user.email == email
     assert user.claims == {"iss": "https://example.com"}
     assert models.User.objects.count() == 1
+
+
+@override_settings(
+    OIDC_USERINFO_ORGANIZATION_CLAIM="siret",
+    OIDC_STORE_CLAIMS=["siret"],
+)
+def test_authentication_new_user_org_claim_also_in_store_claims(monkeypatch):
+    """Regression: when the organization claim is also listed in
+    OIDC_STORE_CLAIMS, it was being nested under ``claims.claims.<key>``
+    and the top-level ``claims.<key>`` lookup in ``_resolve_org_external_id``
+    returned None, raising SuspiciousOperation on user creation.
+
+    The org claim must be surfaced at the top level of the extra claims
+    so create_user can resolve the organization.
+    """
+    klass = OIDCAuthenticationBackend()
+
+    def get_userinfo_mocked(*args):
+        return {
+            "sub": "456",
+            "email": "alice@ministry.gouv.fr",
+            "given_name": "Alice",
+            "usual_name": "Martin",
+            "siret": "13002526500013",
+        }
+
+    monkeypatch.setattr(OIDCAuthenticationBackend, "get_userinfo", get_userinfo_mocked)
+
+    user = klass.get_or_create_user(
+        access_token="test-token", id_token=None, payload=None
+    )
+
+    assert user is not None
+    assert user.sub == "456"
+    assert user.email == "alice@ministry.gouv.fr"
+    assert user.organization is not None
+    assert user.organization.external_id == "13002526500013"
+    assert user.claims == {"siret": "13002526500013"}

--- a/src/backend/core/tests/test_audit_tracking.py
+++ b/src/backend/core/tests/test_audit_tracking.py
@@ -27,9 +27,10 @@ CHANNELS_URL = "/api/v1.0/channels/"
 
 def _basic_auth(email, channel_id, token):
     """Build Basic Auth header matching the public CalDAV password format
-    (``base64(email:urlsafe_channel_id:token)``)."""
+    (``base64(email:<urlsafe_channel_id><token>)``, no separator between
+    channel id and token)."""
     short_id = uuid_to_urlsafe(channel_id)
-    creds = base64.b64encode(f"{email}:{short_id}:{token}".encode()).decode()
+    creds = base64.b64encode(f"{email}:{short_id}{token}".encode()).decode()
     return f"Basic {creds}"
 
 

--- a/src/backend/core/tests/test_channels.py
+++ b/src/backend/core/tests/test_channels.py
@@ -25,9 +25,13 @@ CHANNELS_URL = "/api/v1.0/channels/"
 def _basic_auth(email, channel_id, token):
     """Build HTTP_AUTHORIZATION header for Basic Auth.
 
-    Format: base64(email:channel_id:token)
+    Format: base64(email:<channel_id><token>). The channel_id is the
+    fixed-length base64url-encoded UUID; a UUID instance is converted
+    automatically for convenience.
     """
-    creds = base64.b64encode(f"{email}:{channel_id}:{token}".encode()).decode()
+    if isinstance(channel_id, uuid.UUID):
+        channel_id = uuid_to_urlsafe(channel_id)
+    creds = base64.b64encode(f"{email}:{channel_id}{token}".encode()).decode()
     return f"Basic {creds}"
 
 
@@ -160,7 +164,8 @@ class TestChannelAPI:
         assert len(data["token"]) >= 20
         assert "password" in data
         short_id = uuid_to_urlsafe(uuid.UUID(data["id"]))
-        assert data["password"] == f"{short_id}:{data['token']}"
+        assert data["password"] == f"{short_id}{data['token']}"
+        assert len(short_id) == 22
         assert data["scopes"] == ["calendars:read", "events:read"]
         assert data["scope_level"] == "user"
         assert data["user"] == str(user.pk)
@@ -1341,18 +1346,18 @@ class TestCalDAVLibraryCompat:
             settings={"scopes": ["calendars:read", "events:read"]},
         )
         token = channel.encrypted_settings["token"]
+        short_id = uuid_to_urlsafe(channel.pk)
 
-        auth = HTTPBasicAuth(user.email, f"{channel.pk}:{token}")
+        auth = HTTPBasicAuth(user.email, f"{short_id}{token}")
         prepared = req_lib.Request("PROPFIND", "http://testserver/caldav/").prepare()
         auth(prepared)
         header = prepared.headers["Authorization"]
 
         decoded = base64.b64decode(header.split(" ")[1]).decode()
-        parts = decoded.split(":", 1)
-        assert parts[0] == user.email
-        cred_parts = parts[1].split(":", 1)
-        assert cred_parts[0] == str(channel.pk)
-        assert cred_parts[1] == token
+        email, credentials = decoded.split(":", 1)
+        assert email == user.email
+        assert credentials[:22] == short_id
+        assert credentials[22:] == token
 
     @patch("core.api.viewsets_caldav.CalDAVHTTPClient")
     def test_caldav_library_auth_accepted_by_proxy(self, mock_http_cls):
@@ -1364,8 +1369,9 @@ class TestCalDAVLibraryCompat:
             settings={"scopes": ["calendars:read", "events:read"]},
         )
         token = channel.encrypted_settings["token"]
+        short_id = uuid_to_urlsafe(channel.pk)
 
-        auth = HTTPBasicAuth(user.email, f"{channel.pk}:{token}")
+        auth = HTTPBasicAuth(user.email, f"{short_id}{token}")
         prepared = req_lib.Request("PROPFIND", "http://testserver/").prepare()
         auth(prepared)
         header = prepared.headers["Authorization"]

--- a/src/caldav/init-database.sh
+++ b/src/caldav/init-database.sh
@@ -29,6 +29,14 @@ export PGDATABASE
 export PGUSER
 export PGPASSWORD
 
+# Optional Postgres schema that will host all sabre/dav tables. When empty
+# or "public", tables land in the default public schema (legacy behavior).
+CALDAV_DB_SCHEMA="${CALDAV_DB_SCHEMA:-public}"
+if ! [[ "$CALDAV_DB_SCHEMA" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+  echo "CALDAV_DB_SCHEMA must be a valid identifier, got: $CALDAV_DB_SCHEMA"
+  exit 1
+fi
+
 # Wait for PostgreSQL to be ready
 retries=30
 until pg_isready -q -h "$PGHOST" -p "$PGPORT" -U "$PGUSER"; do
@@ -54,8 +62,16 @@ echo "PostgreSQL is ready. Initializing sabre/dav database schema..."
 # SQL files directory (configurable for Scalingo, defaults to Docker path)
 SQL_DIR="${SQL_DIR:-/var/www/sabredav/sql}"
 
+# Ensure the target schema exists, then route every subsequent psql call
+# through it via libpq's PGOPTIONS. Unqualified CREATE TABLE / SELECT in
+# the .sql files will resolve to this schema.
+if [ "$CALDAV_DB_SCHEMA" != "public" ]; then
+  psql -c "CREATE SCHEMA IF NOT EXISTS \"$CALDAV_DB_SCHEMA\""
+fi
+export PGOPTIONS="-c search_path=\"$CALDAV_DB_SCHEMA\",public"
+
 # Check if tables already exist
-TABLES_EXIST=$(psql -tAc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name IN ('users', 'principals', 'calendars')" 2>/dev/null || echo "0")
+TABLES_EXIST=$(psql -tAc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '$CALDAV_DB_SCHEMA' AND table_name IN ('users', 'principals', 'calendars')" 2>/dev/null || echo "0")
 
 if [ "$TABLES_EXIST" -gt "0" ]; then
   echo "sabre/dav tables already exist, skipping table creation"

--- a/src/caldav/server.php
+++ b/src/caldav/server.php
@@ -55,6 +55,15 @@ $pdo = new PDO(
     ]
 );
 
+// Route all unqualified table references to the configured schema.
+// Defaults to "public" so existing deployments are unaffected.
+$dbSchema = getenv('CALDAV_DB_SCHEMA') ?: 'public';
+if (!preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $dbSchema)) {
+    error_log("[sabre/dav] CALDAV_DB_SCHEMA must be a valid identifier, got: {$dbSchema}");
+    exit(1);
+}
+$pdo->exec("SET search_path TO \"{$dbSchema}\", public");
+
 // Create custom authentication backend
 // Requires API key authentication and X-LS-User header
 $apiKey = getenv('CALDAV_OUTBOUND_API_KEY');

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/EventModal.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/EventModal.tsx
@@ -102,20 +102,21 @@ export const EventModal = ({
     return undefined;
   }, [event?.organizer, form.selectedCalendarUrl, calendars, user]);
 
-  // Defensive: if the form's selected calendar URL is empty or doesn't
-  // match any entry in the dropdown's options (stale state, race
-  // condition between calendar creation and modal open, URL trailing-
-  // slash mismatch…), auto-snap to the first available calendar so the
-  // user always sees something selected and Save is enabled.
+  // Defensive fallback to keep a valid selection when the caller did
+  // not pass one (e.g. "new event" from a context with no default
+  // calendar). When `calendarUrl` is non-empty we trust it, even if
+  // it isn't in `calendars` yet — the list may still be loading and
+  // auto-snapping to calendars[0] here would stomp the correct choice.
   useEffect(() => {
     if (!isOpen || calendars.length === 0) return;
-    const isValid = calendars.some(
+    if (calendarUrl) return;
+    const currentIsValid = calendars.some(
       (cal) => cal.url === form.selectedCalendarUrl,
     );
-    if (!isValid) {
+    if (!currentIsValid) {
       form.setSelectedCalendarUrl(calendars[0].url);
     }
-  }, [isOpen, calendars, form]);
+  }, [isOpen, calendars, calendarUrl, form]);
 
   // Check if current user is invited
   const currentUserAttendee = event?.attendees?.find(

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/Scheduler.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/Scheduler.tsx
@@ -381,6 +381,7 @@ export const Scheduler = ({ defaultCalendarUrl }: SchedulerProps) => {
       {isMobile && <FloatingActionButton onClick={handleFabClick} />}
 
       <EventModal
+        key={modalState.event?.uid ?? "none"}
         isOpen={modalState.isOpen}
         mode={modalState.mode}
         event={modalState.event}

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/Scheduler.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/Scheduler.tsx
@@ -381,7 +381,11 @@ export const Scheduler = ({ defaultCalendarUrl }: SchedulerProps) => {
       {isMobile && <FloatingActionButton onClick={handleFabClick} />}
 
       <EventModal
-        key={modalState.event?.uid ?? "none"}
+        key={`${modalState.mode}-${modalState.event?.uid ?? "none"}-${
+          modalState.event?.recurrenceId?.value?.date instanceof Date
+            ? modalState.event.recurrenceId.value.date.getTime()
+            : ""
+        }`}
         isOpen={modalState.isOpen}
         mode={modalState.mode}
         event={modalState.event}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin action to regenerate channel authentication tokens with one-time display
  * Admin user editor exposes organization selection

* **Bug Fixes**
  * Calendar event modal respects caller-provided calendar URL and remounts when context changes

* **Documentation**
  * CalDAV authentication credential format and examples updated

* **Chores**
  * Improved CalDAV healthcheck and added configurable CalDAV DB schema support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->