### PR TITLE
🐛(move) fix moving events between calendars

### DIFF
--- a/src/backend/calendars/settings.py
+++ b/src/backend/calendars/settings.py
@@ -476,6 +476,7 @@ class Base(Configuration):
         "REPORT",
         "MKCOL",
         "MKCALENDAR",
+        "MOVE",
     ]
     # Allow CalDAV headers (case-sensitive for CORS preflight)
     CORS_ALLOW_HEADERS = [
@@ -492,6 +493,8 @@ class Base(Configuration):
         "if-match",
         "if-none-match",
         "prefer",
+        "destination",  # WebDAV MOVE target URL
+        "overwrite",  # WebDAV MOVE overwrite flag
     ]
 
     # Sentry

--- a/src/backend/core/api/viewsets_caldav.py
+++ b/src/backend/core/api/viewsets_caldav.py
@@ -5,6 +5,7 @@ import binascii
 import logging
 import re
 import secrets
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -24,6 +25,30 @@ from core.services.caldav_service import CalDAVHTTPClient, validate_caldav_proxy
 from core.services.calendar_invitation_service import calendar_invitation_service
 
 logger = logging.getLogger(__name__)
+
+
+# Methods the proxy will forward to SabreDAV. Anything outside this set
+# returns 405 before authentication is even consulted. Defense in depth:
+# SabreDAV's own ACL is the source of truth, but limiting the verb
+# surface here means a future Sabre plugin (LOCK, ACL writes, etc.)
+# cannot be reached without an explicit proxy update. This set must
+# also be advertised in the OPTIONS preflight response so browser
+# clients can discover what they're allowed to send.
+ALLOWED_PROXY_METHODS = frozenset(
+    {
+        "GET",
+        "OPTIONS",
+        "PROPFIND",
+        "PROPPATCH",
+        "REPORT",
+        "MKCOL",
+        "MKCALENDAR",
+        "PUT",
+        "DELETE",
+        "POST",
+        "MOVE",
+    }
+)
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -180,8 +205,9 @@ class CalDAVProxyView(View):
         return True
 
     @staticmethod
-    def _check_entitlements_for_creation(user):
-        """Check if user is entitled to create calendars.
+    def _check_entitlements_for_calendar_management(user):
+        """Check if user is entitled to manage their calendars
+        (create or delete).
 
         Returns None if allowed, or an HttpResponse(403) if denied.
         Fail-closed: denies if the entitlements service is unavailable.
@@ -191,12 +217,12 @@ class CalDAVProxyView(View):
             if not entitlements.get("can_access", False):
                 return HttpResponse(
                     status=403,
-                    content="Calendar creation not allowed",
+                    content="Calendar management not allowed",
                 )
         except EntitlementsUnavailableError:
             return HttpResponse(
                 status=403,
-                content="Calendar creation not allowed",
+                content="Calendar management not allowed",
             )
         return None
 
@@ -204,13 +230,20 @@ class CalDAVProxyView(View):
         """Forward all HTTP methods to CalDAV server."""
         if request.method == "OPTIONS":
             response = HttpResponse(status=200)
-            response["Access-Control-Allow-Methods"] = (
-                "GET, OPTIONS, PROPFIND, PROPPATCH, REPORT,"
-                " MKCOL, MKCALENDAR, PUT, DELETE, POST"
+            response["Access-Control-Allow-Methods"] = ", ".join(
+                sorted(ALLOWED_PROXY_METHODS)
             )
             response["Access-Control-Allow-Headers"] = (
-                "Content-Type, depth, authorization, if-match, if-none-match, prefer"
+                "Content-Type, depth, authorization, if-match, if-none-match,"
+                " prefer, destination, overwrite"
             )
+            return response
+
+        if request.method not in ALLOWED_PROXY_METHODS:
+            response = HttpResponse(
+                status=405, content="Method not allowed by CalDAV proxy"
+            )
+            response["Allow"] = ", ".join(sorted(ALLOWED_PROXY_METHODS))
             return response
 
         channel = None
@@ -238,8 +271,16 @@ class CalDAVProxyView(View):
                     content="Method not allowed for channel scopes",
                 )
 
-        if request.method in ("MKCALENDAR", "MKCOL"):
-            if denied := self._check_entitlements_for_creation(effective_user):
+        # Calendar lifecycle (create/delete) is gated by the same entitlement.
+        # Object-level DELETE (events, ending in .ics) is unrestricted; only
+        # DELETE on a calendar collection (path ending /) needs the gate.
+        is_collection_delete = request.method == "DELETE" and self._is_collection_path(
+            path
+        )
+        if request.method in ("MKCALENDAR", "MKCOL") or is_collection_delete:
+            if denied := self._check_entitlements_for_calendar_management(
+                effective_user
+            ):
                 return denied
 
         if not validate_caldav_proxy_path(path):
@@ -274,6 +315,25 @@ class CalDAVProxyView(View):
             headers["If-None-Match"] = request.META["HTTP_IF_NONE_MATCH"]
         if "HTTP_PREFER" in request.META:
             headers["Prefer"] = request.META["HTTP_PREFER"]
+        if request.method == "MOVE" and "HTTP_OVERWRITE" in request.META:
+            headers["Overwrite"] = request.META["HTTP_OVERWRITE"]
+        if request.method == "MOVE" and "HTTP_DESTINATION" in request.META:
+            # Translate the public Destination URL to the upstream CalDAV URL.
+            # The client sends an absolute URL pointing at this proxy
+            # (e.g. http://host/caldav/calendars/.../x.ics); SabreDAV expects
+            # a URL on its own server. We extract the path and rebuild it
+            # against the upstream base. Validate the path to avoid
+            # smuggling traversal/internal-api targets via the header.
+            dest_path = urlparse(request.META["HTTP_DESTINATION"]).path
+            if dest_path.startswith("/caldav/"):
+                dest_clean_path = dest_path[len("/caldav/") :]
+            elif dest_path.startswith("/caldav"):
+                dest_clean_path = dest_path[len("/caldav") :].lstrip("/")
+            else:
+                dest_clean_path = dest_path.lstrip("/")
+            if not validate_caldav_proxy_path(dest_clean_path):
+                return HttpResponse(status=400, content="Invalid destination")
+            headers["Destination"] = http.build_url(dest_clean_path)
 
         body = request.body if request.body else None
 

--- a/src/backend/core/api/viewsets_caldav.py
+++ b/src/backend/core/api/viewsets_caldav.py
@@ -262,8 +262,9 @@ class CalDAVProxyView(View):
         else:
             effective_user = request.user
 
+        is_collection = self._is_collection_path(path)
+
         if channel:
-            is_collection = self._is_collection_path(path)
             allowed = channel.allowed_methods(collection=is_collection)
             if request.method not in allowed:
                 return HttpResponse(
@@ -271,13 +272,19 @@ class CalDAVProxyView(View):
                     content="Method not allowed for channel scopes",
                 )
 
-        # Calendar lifecycle (create/delete) is gated by the same entitlement.
-        # Object-level DELETE (events, ending in .ics) is unrestricted; only
-        # DELETE on a calendar collection (path ending /) needs the gate.
-        is_collection_delete = request.method == "DELETE" and self._is_collection_path(
-            path
-        )
-        if request.method in ("MKCALENDAR", "MKCOL") or is_collection_delete:
+        # Calendar lifecycle (create/rename/delete) is gated by the same
+        # entitlement. Object-level DELETE/MOVE (events, ending in .ics)
+        # is unrestricted; only operations on a calendar collection (path
+        # ending /) need the gate. MOVE on a collection is the rename
+        # path — symmetric with MKCALENDAR + DELETE so we don't trust
+        # SabreDAV alone to gate it.
+        is_collection_delete = request.method == "DELETE" and is_collection
+        is_collection_move = request.method == "MOVE" and is_collection
+        if (
+            request.method in ("MKCALENDAR", "MKCOL")
+            or is_collection_delete
+            or is_collection_move
+        ):
             if denied := self._check_entitlements_for_calendar_management(
                 effective_user
             ):
@@ -315,6 +322,12 @@ class CalDAVProxyView(View):
             headers["If-None-Match"] = request.META["HTTP_IF_NONE_MATCH"]
         if "HTTP_PREFER" in request.META:
             headers["Prefer"] = request.META["HTTP_PREFER"]
+        # NOTE: Destination/Overwrite forwarding below is gated on MOVE
+        # specifically. If COPY is ever added to ALLOWED_PROXY_METHODS,
+        # this gate must be widened to ("MOVE", "COPY") — otherwise COPY
+        # would forward without the public→upstream URL rewrite and
+        # SabreDAV would either fail or interpret a public-host URL as
+        # remote, depending on deploy.
         if request.method == "MOVE" and "HTTP_OVERWRITE" in request.META:
             headers["Overwrite"] = request.META["HTTP_OVERWRITE"]
         if request.method == "MOVE" and "HTTP_DESTINATION" in request.META:

--- a/src/backend/core/api/viewsets_caldav.py
+++ b/src/backend/core/api/viewsets_caldav.py
@@ -272,12 +272,18 @@ class CalDAVProxyView(View):
                     content="Method not allowed for channel scopes",
                 )
 
-        # Calendar lifecycle (create/rename/delete) is gated by the same
-        # entitlement. Object-level DELETE/MOVE (events, ending in .ics)
-        # is unrestricted; only operations on a calendar collection (path
-        # ending /) need the gate. MOVE on a collection is the rename
-        # path — symmetric with MKCALENDAR + DELETE so we don't trust
-        # SabreDAV alone to gate it.
+        # Calendar lifecycle is gated by the entitlement. Object-level
+        # DELETE/MOVE (events, ending in .ics) is unrestricted — losing
+        # an entitlement must never strand a user with events they can't
+        # remove or reorganize. Collection DELETE is the canonical
+        # destructive lifecycle op and gets the gate.
+        #
+        # Collection MOVE is included defensively even though SabreDAV
+        # doesn't currently support it (calendar rename is done via
+        # PROPPATCH on displayname, not MOVE). If a future plugin or
+        # SabreDAV release ever made collection MOVE work, it would be a
+        # destructive lifecycle op too — gating it here means we don't
+        # have to remember to add the gate at that point.
         is_collection_delete = request.method == "DELETE" and is_collection
         is_collection_move = request.method == "MOVE" and is_collection
         if (

--- a/src/backend/core/api/viewsets_caldav.py
+++ b/src/backend/core/api/viewsets_caldav.py
@@ -331,8 +331,23 @@ class CalDAVProxyView(View):
                 dest_clean_path = dest_path[len("/caldav") :].lstrip("/")
             else:
                 dest_clean_path = dest_path.lstrip("/")
+            # An empty/root destination is meaningless for MOVE on an
+            # event resource and would let callers smuggle a relocation
+            # to the upstream calendar root past the prefix allowlist.
+            if not dest_clean_path:
+                return HttpResponse(status=400, content="Invalid destination")
             if not validate_caldav_proxy_path(dest_clean_path):
                 return HttpResponse(status=400, content="Invalid destination")
+            # Channel scope must contain the destination just like the
+            # source. Without this, a CALENDAR-scoped channel could MOVE
+            # an event out of its scoped calendar into another calendar
+            # of the same user. MOVE isn't in any channel scope today
+            # (it 403s earlier at the method-allowlist gate), but the
+            # check is required the moment that changes.
+            if channel and not self._check_channel_path_access(
+                channel, dest_clean_path
+            ):
+                return HttpResponse(status=403, content="Forbidden destination")
             headers["Destination"] = http.build_url(dest_clean_path)
 
         body = request.body if request.body else None

--- a/src/backend/core/services/caldav_service.py
+++ b/src/backend/core/services/caldav_service.py
@@ -804,15 +804,23 @@ def validate_caldav_proxy_path(path):
     if not path:
         return True  # Empty path is fine (root request)
 
-    # Decode percent-encoded characters before validation
-    path = unquote(path)
-
-    # Block directory traversal
-    if ".." in path:
+    # Decode percent-encoded characters before validation. Loop until the
+    # decoding is stable so a double-encoded payload (e.g. ``%252e%252e``,
+    # which decodes to ``%2e%2e`` and then to ``..``) cannot smuggle a
+    # traversal past the literal ``..`` check below. Bound the loop to a
+    # small constant to defeat any pathological repeated-encoding input.
+    for _ in range(5):
+        decoded = unquote(path)
+        if decoded == path:
+            break
+        path = decoded
+    else:
+        # Decoding never stabilized — too many layers of encoding,
+        # something hostile.
         return False
 
-    # Block null bytes
-    if "\x00" in path:
+    # Block directory traversal and null bytes
+    if ".." in path or "\x00" in path:
         return False
 
     clean = path.lstrip("/")

--- a/src/backend/core/services/caldav_service.py
+++ b/src/backend/core/services/caldav_service.py
@@ -796,6 +796,7 @@ def validate_caldav_proxy_path(path):
     Prevents path traversal attacks by rejecting paths with:
     - Directory traversal sequences (../)
     - Null bytes
+    - ASCII control characters (CR, LF, tab, etc.)
     - Paths that don't start with expected prefixes
 
     URL-decodes the path first so that encoded payloads like
@@ -819,8 +820,14 @@ def validate_caldav_proxy_path(path):
         # something hostile.
         return False
 
-    # Block directory traversal and null bytes
-    if ".." in path or "\x00" in path:
+    # Block directory traversal, null bytes, and ASCII control bytes
+    # (CR/LF/tab/etc.). Header forwarding downstream catches CRLF on its
+    # own (urllib3 raises InvalidHeader), but this function is the
+    # documented gate — relying on a downstream library to refuse what we
+    # claim to validate ourselves is the wrong shape. Cheap rejection
+    # here also keeps log lines from carrying injected newlines if a
+    # malformed path ever reaches the debug logger before forwarding.
+    if ".." in path or any(0 <= ord(c) < 0x20 or ord(c) == 0x7F for c in path):
         return False
 
     clean = path.lstrip("/")

--- a/src/backend/core/tests/test_caldav_proxy.py
+++ b/src/backend/core/tests/test_caldav_proxy.py
@@ -875,6 +875,31 @@ class TestValidateCaldavProxyPath:
             validate_caldav_proxy_path("calendars/%25252e%25252e/etc/passwd") is False
         )
 
+    @pytest.mark.parametrize(
+        "raw,description",
+        [
+            ("calendars/users/me/cal/\rfoo.ics", "CR"),
+            ("calendars/users/me/cal/\nfoo.ics", "LF"),
+            ("calendars/users/me/cal/\r\nX-Header: pwn", "CRLF header injection"),
+            ("calendars/users/me/cal/\tfoo.ics", "tab"),
+            ("calendars/users/me/cal/foo\x7f.ics", "DEL (0x7F)"),
+            ("calendars/users/me/cal/foo\x01.ics", "SOH (0x01)"),
+            ("calendars/users/me/cal/foo%0A.ics", "URL-encoded LF"),
+            ("calendars/users/me/cal/foo%0d.ics", "URL-encoded CR (lowercase)"),
+        ],
+    )
+    def test_control_characters_are_rejected(self, raw, description):
+        """ASCII control bytes (CR/LF/tab/DEL/etc., raw or %-encoded) are
+        rejected by the validator itself rather than relying on
+        downstream libraries (urllib3 raises on CRLF in headers, but the
+        validator is the documented gate). Also defends the debug logger
+        against newline-injected log lines if a malformed path ever
+        reached it before forwarding.
+        """
+        assert validate_caldav_proxy_path(raw) is False, (
+            f"Expected control char ({description}) to be rejected"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Internal API test helpers

--- a/src/backend/core/tests/test_caldav_proxy.py
+++ b/src/backend/core/tests/test_caldav_proxy.py
@@ -1,8 +1,10 @@
 """Tests for CalDAV proxy view."""
 
-# pylint: disable=no-member
+# pylint: disable=no-member,too-many-lines
 
+import base64
 import json
+from unittest import mock
 from xml.etree import ElementTree as ET
 
 from django.conf import settings
@@ -17,7 +19,11 @@ from rest_framework.status import (
 )
 from rest_framework.test import APIClient
 
+from core import enums as core_enums
 from core import factories
+from core import models as core_models
+from core.enums import ChannelScope
+from core.models import uuid_to_urlsafe
 from core.services.caldav_service import CalDAVHTTPClient, validate_caldav_proxy_path
 
 
@@ -427,6 +433,84 @@ class TestCalDAVProxy:
             HTTP_DESTINATION=("http://example/caldav/calendars/%252e%252e/etc/passwd"),
         )
         assert response.status_code == HTTP_400_BAD_REQUEST
+
+    def test_proxy_rejects_move_with_empty_destination(self):
+        """A MOVE whose Destination resolves to the calendar root (no
+        path beyond ``/caldav/``) must be rejected with 400 — the
+        current prefix allowlist treats an empty path as valid (it's
+        used for the root PROPFIND), so without an explicit empty-path
+        check a caller could smuggle a relocation to the upstream root.
+        """
+        user = factories.UserFactory(email="test@example.com")
+        client = APIClient()
+        client.force_login(user)
+
+        source_path = "/caldav/calendars/users/test@example.com/cal-a/event-uid.ics"
+
+        # Destination URL with the proxy prefix but nothing beyond.
+        response = client.generic(
+            "MOVE", source_path, HTTP_DESTINATION="http://example/caldav/"
+        )
+        assert response.status_code == HTTP_400_BAD_REQUEST
+
+        # Destination URL that resolves to the absolute server root.
+        response = client.generic(
+            "MOVE", source_path, HTTP_DESTINATION="http://example/"
+        )
+        assert response.status_code == HTTP_400_BAD_REQUEST
+
+    def test_proxy_rejects_move_destination_outside_channel_scope(self):
+        """When MOVE is allowed for a channel scope, the destination
+        path must be subject to the same scope check as the source.
+        Without this, a CALENDAR-scoped channel could MOVE an event
+        out of its scoped calendar into another calendar of the same
+        user — bypassing the scope.
+
+        MOVE isn't in any production channel scope today, so this test
+        patches it in to exercise the destination-scope code path
+        directly. If a future PR adds MOVE to a real scope, this test
+        keeps the destination check honest.
+        """
+        user = factories.UserFactory(email="test@example.com")
+        channel = factories.ChannelFactory(
+            user=user,
+            type="caldav",
+            scope_level="calendar",
+            caldav_path=f"/calendars/users/{user.email}/cal-a/",
+            settings={"scopes": ["events:read", "events:write"]},
+            is_active=True,
+        )
+        token = channel.encrypted_settings["token"]
+        chan_id = uuid_to_urlsafe(channel.pk)
+        creds = base64.b64encode(f"{user.email}:{chan_id}{token}".encode()).decode()
+
+        client = APIClient()
+        source_path = f"/caldav/calendars/users/{user.email}/cal-a/event.ics"
+        out_of_scope_dest = (
+            f"http://example/caldav/calendars/users/{user.email}/cal-b/event.ics"
+        )
+
+        # Patch MOVE into the EVENTS_WRITE object scope so we reach the
+        # destination check (otherwise we'd 403 at the method gate).
+        # The patch target is `core.models` because that module captured
+        # its own binding to the dict at import time.
+        patched_methods = dict(core_enums.CHANNEL_SCOPE_OBJECT_METHODS)
+        patched_methods[ChannelScope.EVENTS_WRITE] = frozenset(
+            patched_methods[ChannelScope.EVENTS_WRITE] | {"MOVE"}
+        )
+
+        with mock.patch.object(
+            core_models, "CHANNEL_SCOPE_OBJECT_METHODS", patched_methods
+        ):
+            response = client.generic(
+                "MOVE",
+                source_path,
+                HTTP_DESTINATION=out_of_scope_dest,
+                HTTP_AUTHORIZATION=f"Basic {creds}",
+            )
+
+        assert response.status_code == 403
+        assert b"Forbidden destination" in response.content
 
     def test_proxy_rejects_path_traversal(self):
         """Test that proxy rejects paths with directory traversal."""

--- a/src/backend/core/tests/test_caldav_proxy.py
+++ b/src/backend/core/tests/test_caldav_proxy.py
@@ -316,6 +316,118 @@ class TestCalDAVProxy:
         assert "Access-Control-Allow-Methods" in response
         assert "PROPFIND" in response["Access-Control-Allow-Methods"]
 
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "LOCK",
+            "UNLOCK",
+            "COPY",
+            "ACL",
+            "SEARCH",
+            "PATCH",
+            "BIND",
+            "REBIND",
+            "UNBIND",
+            "ORDERPATCH",
+        ],
+    )
+    def test_proxy_rejects_unknown_methods(self, method):
+        """Methods outside the allowlist are rejected with 405 before the
+        request ever reaches SabreDAV.
+
+        This is defense in depth: SabreDAV may add plugins (LOCK, ACL
+        writes, etc.) over time, but the proxy must opt them in
+        explicitly. A 405 here also exposes ``Allow`` so clients can
+        discover the supported set.
+        """
+        user = factories.UserFactory(email="test@example.com")
+        client = APIClient()
+        client.force_login(user)
+
+        response = client.generic(method, "/caldav/calendars/users/test@example.com/")
+
+        assert response.status_code == 405
+        # Allow header advertises the canonical proxy method set.
+        allow = response.get("Allow", "")
+        for expected in ("MOVE", "PROPFIND", "REPORT", "MKCALENDAR"):
+            assert expected in allow
+
+    @responses.activate
+    def test_proxy_forwards_move_with_destination_rewrite(self):
+        """MOVE forwards Destination/Overwrite to upstream, with the
+        public URL in the Destination header rewritten to point at the
+        upstream CalDAV server (so SabreDAV recognizes the destination
+        as on its own host)."""
+        user = factories.UserFactory(email="test@example.com")
+        client = APIClient()
+        client.force_login(user)
+
+        caldav_url = settings.CALDAV_URL
+        source_path = "/caldav/calendars/users/test@example.com/cal-a/event-uid.ics"
+        upstream_source = f"{caldav_url}{source_path}"
+        upstream_dest = (
+            f"{caldav_url}/caldav/calendars/users/test@example.com/cal-b/event-uid.ics"
+        )
+
+        responses.add(
+            responses.Response(
+                method="MOVE",
+                url=upstream_source,
+                status=201,
+                body="",
+            )
+        )
+
+        # Client sends an absolute URL pointing at the public proxy host;
+        # the proxy must rewrite it to the upstream URL before forwarding.
+        public_destination = (
+            "http://example-public-host/caldav/calendars/users/"
+            "test@example.com/cal-b/event-uid.ics"
+        )
+        response = client.generic(
+            "MOVE",
+            source_path,
+            HTTP_DESTINATION=public_destination,
+            HTTP_OVERWRITE="F",
+        )
+
+        assert response.status_code == 201
+        assert len(responses.calls) == 1
+        forwarded = responses.calls[0].request
+        assert forwarded.headers["Destination"] == upstream_dest
+        assert forwarded.headers["Overwrite"] == "F"
+
+    def test_proxy_rejects_move_with_invalid_destination(self):
+        """A Destination pointing at /internal-api/ or with traversal
+        must be rejected before forwarding upstream."""
+        user = factories.UserFactory(email="test@example.com")
+        client = APIClient()
+        client.force_login(user)
+
+        source_path = "/caldav/calendars/users/test@example.com/cal-a/event-uid.ics"
+
+        response = client.generic(
+            "MOVE",
+            source_path,
+            HTTP_DESTINATION="http://example/caldav/internal-api/sync_acls",
+        )
+        assert response.status_code == HTTP_400_BAD_REQUEST
+
+        response = client.generic(
+            "MOVE",
+            source_path,
+            HTTP_DESTINATION="http://example/caldav/calendars/../etc/passwd",
+        )
+        assert response.status_code == HTTP_400_BAD_REQUEST
+
+        # Double-encoded traversal: %252e%252e -> %2e%2e -> ..
+        response = client.generic(
+            "MOVE",
+            source_path,
+            HTTP_DESTINATION=("http://example/caldav/calendars/%252e%252e/etc/passwd"),
+        )
+        assert response.status_code == HTTP_400_BAD_REQUEST
+
     def test_proxy_rejects_path_traversal(self):
         """Test that proxy rejects paths with directory traversal."""
         user = factories.UserFactory(email="test@example.com")
@@ -662,6 +774,22 @@ class TestValidateCaldavProxyPath:
     def test_encoded_null_byte_is_rejected(self):
         """URL-encoded null byte should be rejected."""
         assert validate_caldav_proxy_path("calendars/user%00/") is False
+
+    def test_double_encoded_traversal_is_rejected(self):
+        """Double URL-encoded traversal (e.g. %252e%252e -> %2e%2e ->
+        ..) must also be rejected.
+
+        The validator unquotes until a fixed point is reached so an
+        attacker cannot smuggle a `..` past the literal-substring check
+        by stacking encoding layers.
+        """
+        assert validate_caldav_proxy_path("calendars/%252e%252e/etc/passwd") is False
+
+    def test_triple_encoded_traversal_is_rejected(self):
+        """Triple URL-encoded traversal should also be rejected."""
+        assert (
+            validate_caldav_proxy_path("calendars/%25252e%25252e/etc/passwd") is False
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/core/tests/test_calendar_sharing_e2e.py
+++ b/src/backend/core/tests/test_calendar_sharing_e2e.py
@@ -1551,6 +1551,49 @@ class TestNoAccessSharing:
             f"got {response.status_code}"
         )
 
+    def test_non_shared_user_cannot_move_events(self):
+        """A non-shared user cannot MOVE events out of another user's calendar.
+
+        The proxy delegates cross-user write enforcement on MOVE to
+        SabreDAV ACL (no proxy-side scope check for OIDC users on
+        either source or destination, mirroring how PUT/DELETE work).
+        This test pins down that delegation: a stranger trying to
+        MOVE an event from the owner's calendar into their own
+        calendar must be rejected, and the event must remain in the
+        owner's calendar afterwards. If a future SabreDAV plugin
+        change opens this up, this test catches it.
+        """
+        org = factories.OrganizationFactory(external_id="no-access-move")
+        owner, owner_client, owner_cal_path = _create_user_with_calendar(
+            org, "owner-nam"
+        )
+        stranger, stranger_client, stranger_cal_path = _create_user_with_calendar(
+            org, "stranger-nam"
+        )
+        owner_cal_id = _get_cal_id(owner_cal_path)
+        stranger_cal_id = _get_cal_id(stranger_cal_path)
+
+        _put_event(owner_client, owner.email, owner_cal_id, "stay-put", "Untouchable")
+
+        src_path = f"/caldav/calendars/users/{owner.email}/{owner_cal_id}/stay-put.ics"
+        dest_path = (
+            f"http://example/caldav/calendars/users/{stranger.email}/"
+            f"{stranger_cal_id}/stay-put.ics"
+        )
+        response = stranger_client.generic("MOVE", src_path, HTTP_DESTINATION=dest_path)
+        assert response.status_code in (403, 404, 409), (
+            f"SECURITY: cross-user MOVE should be blocked by SabreDAV ACL, "
+            f"got {response.status_code}"
+        )
+
+        # The event must still be readable by the owner — i.e. the MOVE
+        # must not have unbound the source even partially.
+        get_resp = _get_event(owner_client, owner.email, owner_cal_id, "stay-put")
+        assert get_resp.status_code == 200, (
+            f"Event must remain in owner's calendar after blocked MOVE, "
+            f"got GET status {get_resp.status_code}"
+        )
+
     def test_non_shared_user_cannot_report_events(self):
         """A non-shared user cannot REPORT on another user's calendar."""
         org = factories.OrganizationFactory(external_id="no-access-report")

--- a/src/backend/core/tests/test_calendar_sharing_e2e.py
+++ b/src/backend/core/tests/test_calendar_sharing_e2e.py
@@ -1554,14 +1554,19 @@ class TestNoAccessSharing:
     def test_non_shared_user_cannot_move_events(self):
         """A non-shared user cannot MOVE events out of another user's calendar.
 
-        The proxy delegates cross-user write enforcement on MOVE to
-        SabreDAV ACL (no proxy-side scope check for OIDC users on
-        either source or destination, mirroring how PUT/DELETE work).
-        This test pins down that delegation: a stranger trying to
-        MOVE an event from the owner's calendar into their own
-        calendar must be rejected, and the event must remain in the
-        owner's calendar afterwards. If a future SabreDAV plugin
-        change opens this up, this test catches it.
+        The proxy is a dumb forwarder for OIDC users: no proxy-side
+        principal/path scope enforcement (mirroring PUT/DELETE).
+        SabreDAV's stock ACL is what blocks this — a stranger has no
+        ``unbind`` privilege on another user's calendar by default —
+        and this test pins that contract.
+
+        MOVE is two-resource, so the test asserts three independent
+        things: the request was rejected, the source event survives in
+        the owner's calendar, and the destination resource was not
+        created in the stranger's calendar. The third assertion guards
+        against partial-success regressions (a future plugin that
+        binds before checking unbind, or that mirrors instead of
+        moves) — those would pass a status-code-only test.
         """
         org = factories.OrganizationFactory(external_id="no-access-move")
         owner, owner_client, owner_cal_path = _create_user_with_calendar(
@@ -1581,17 +1586,28 @@ class TestNoAccessSharing:
             f"{stranger_cal_id}/stay-put.ics"
         )
         response = stranger_client.generic("MOVE", src_path, HTTP_DESTINATION=dest_path)
-        assert response.status_code in (403, 404, 409), (
+        assert response.status_code in (403, 404), (
             f"SECURITY: cross-user MOVE should be blocked by SabreDAV ACL, "
             f"got {response.status_code}"
         )
 
-        # The event must still be readable by the owner — i.e. the MOVE
-        # must not have unbound the source even partially.
-        get_resp = _get_event(owner_client, owner.email, owner_cal_id, "stay-put")
-        assert get_resp.status_code == 200, (
+        # Source: still in the owner's calendar (not unbound).
+        get_src = _get_event(owner_client, owner.email, owner_cal_id, "stay-put")
+        assert get_src.status_code == 200, (
             f"Event must remain in owner's calendar after blocked MOVE, "
-            f"got GET status {get_resp.status_code}"
+            f"got GET status {get_src.status_code}"
+        )
+
+        # Destination: not created in the stranger's calendar (no
+        # partial bind). Use the stranger's own client so a 404 here is
+        # genuine absence, not an ACL refusal.
+        get_dst = _get_event(
+            stranger_client, stranger.email, stranger_cal_id, "stay-put"
+        )
+        assert get_dst.status_code == 404, (
+            f"SECURITY: blocked MOVE must not have created the destination "
+            f"resource in the stranger's calendar, got GET status "
+            f"{get_dst.status_code}"
         )
 
     def test_non_shared_user_cannot_report_events(self):

--- a/src/backend/core/tests/test_calendar_sharing_e2e.py
+++ b/src/backend/core/tests/test_calendar_sharing_e2e.py
@@ -2122,7 +2122,12 @@ class TestFreebusyEnforcement:
             f"/caldav/{src_path}",
             HTTP_DESTINATION=dest_path,
         )
-        assert response.status_code in (403, 409), (
+        # Accepted blocking statuses:
+        #   - 403/409: SabreDAV ACL or scheduling plugin rejected the COPY.
+        #   - 405: the Django proxy's method allowlist refuses COPY at the
+        #     edge (defense in depth — strictly stronger than ACL-level
+        #     blocking, since the request never reaches SabreDAV).
+        assert response.status_code in (403, 405, 409), (
             f"SECURITY: COPY from freebusy calendar should be blocked, "
             f"got {response.status_code}"
         )

--- a/src/backend/core/tests/test_calendar_sharing_e2e.py
+++ b/src/backend/core/tests/test_calendar_sharing_e2e.py
@@ -2138,7 +2138,7 @@ class TestFreebusyEnforcement:
             except Exception:  # noqa: BLE001
                 continue
 
-    def test_freebusy_sharee_cannot_copy_event(self):
+    def test_freebusy_sharee_cannot_copy_event(self):  # pylint: disable=too-many-locals
         """Freebusy sharee MUST NOT be able to COPY events to their own calendar."""
         org = factories.OrganizationFactory(external_id="fb-copy-block")
         owner, owner_client, cal_path = _create_user_with_calendar(org, "owner-fbcp")
@@ -2200,16 +2200,28 @@ class TestFreebusyEnforcement:
         # proxy-level blocking; if COPY is ever added to the proxy
         # allowlist, both branches will need to reflect Sabre-side
         # enforcement instead.
-        rw_sharee, _, _ = _create_user_with_calendar(org, "rw-sharee-fbcp")
+        rw_sharee, _, rw_sharee_cal_path = _create_user_with_calendar(
+            org, "rw-sharee-fbcp"
+        )
+        rw_sharee_cal_id = _get_cal_id(rw_sharee_cal_path)
         rw_sharee_client = APIClient()
         rw_sharee_client.force_login(rw_sharee)
         _share_calendar_via_caldav(
             owner_client, owner, cal_id, rw_sharee.email, "read-write"
         )
+        # Destination must be the rw_sharee's own calendar — using the
+        # freebusy sharee's path would mix in unrelated cross-user ACL
+        # effects and muddle the signal the moment COPY is added to the
+        # proxy allowlist (which is precisely what this sanity check
+        # exists to catch).
+        dest_path_rw = (
+            f"/caldav/calendars/users/{rw_sharee.email}/"
+            f"{rw_sharee_cal_id}/copied-event.ics"
+        )
         rw_response = rw_sharee_client.generic(
             "COPY",
             f"/caldav/{src_path}",
-            HTTP_DESTINATION=dest_path,
+            HTTP_DESTINATION=dest_path_rw,
         )
         assert rw_response.status_code == 405, (
             "Expected proxy-level 405 on COPY for a non-freebusy "

--- a/src/backend/core/tests/test_calendar_sharing_e2e.py
+++ b/src/backend/core/tests/test_calendar_sharing_e2e.py
@@ -2132,6 +2132,34 @@ class TestFreebusyEnforcement:
             f"got {response.status_code}"
         )
 
+        # Sanity check: if the freebusy block above resolved as 405, that
+        # was the proxy's global COPY-not-allowed gate, not the
+        # freebusy-specific ACL. Prove that by issuing the same COPY as a
+        # non-freebusy READ-WRITE sharee — they should get 405 too,
+        # because the proxy blocks COPY for everyone. This documents that
+        # the freebusy assertion above is currently dominated by
+        # proxy-level blocking; if COPY is ever added to the proxy
+        # allowlist, both branches will need to reflect Sabre-side
+        # enforcement instead.
+        rw_sharee, _, _ = _create_user_with_calendar(org, "rw-sharee-fbcp")
+        rw_sharee_client = APIClient()
+        rw_sharee_client.force_login(rw_sharee)
+        _share_calendar_via_caldav(
+            owner_client, owner, cal_id, rw_sharee.email, "read-write"
+        )
+        rw_response = rw_sharee_client.generic(
+            "COPY",
+            f"/caldav/{src_path}",
+            HTTP_DESTINATION=dest_path,
+        )
+        assert rw_response.status_code == 405, (
+            "Expected proxy-level 405 on COPY for a non-freebusy "
+            "read-write sharee (the proxy blocks COPY for everyone). "
+            f"Got {rw_response.status_code}; if Sabre rejected this "
+            "instead, COPY may have been added to the proxy allowlist "
+            "and the freebusy assertion above must be re-tightened."
+        )
+
 
 # ===================================================================
 # MailboxShareRestrictionPlugin (moved from test_plugins_e2e)

--- a/src/backend/core/tests/test_entitlements.py
+++ b/src/backend/core/tests/test_entitlements.py
@@ -481,6 +481,72 @@ class TestCalDAVProxyEntitlements:  # pylint: disable=no-member
         assert response.status_code == HTTP_403_FORBIDDEN
 
     @responses.activate
+    def test_collection_move_blocked_when_not_entitled(self):
+        """MOVE on a calendar collection (path ending /) is the rename
+        path — gated by the same entitlement as MKCALENDAR / collection
+        DELETE. Calendar lifecycle stays symmetric whether the user
+        creates, renames, or deletes a collection.
+        """
+        user = factories.UserFactory(email="test@example.com")
+        client = APIClient()
+        client.force_login(user)
+
+        with mock.patch(
+            "core.api.viewsets_caldav.get_user_entitlements",
+            return_value={"can_access": False},
+        ):
+            response = client.generic(
+                "MOVE",
+                "/caldav/calendars/users/test@example.com/cal-id/",
+                HTTP_DESTINATION=(
+                    "http://example/caldav/calendars/users/test@example.com/"
+                    "renamed-cal/"
+                ),
+            )
+
+        assert response.status_code == HTTP_403_FORBIDDEN
+
+    @responses.activate
+    def test_object_move_does_not_check_entitlement(self):
+        """MOVE on an event (path ending .ics) is NOT gated by
+        entitlements — only the calendar lifecycle is. Reorganizing
+        one's own events between calendars must always work,
+        regardless of subscription state.
+        """
+        user = factories.UserFactory(email="test@example.com")
+        client = APIClient()
+        client.force_login(user)
+
+        caldav_url = settings.CALDAV_URL
+        responses.add(
+            responses.Response(
+                method="MOVE",
+                url=(
+                    f"{caldav_url}/caldav/calendars/users/test@example.com/"
+                    "cal-a/event-uid.ics"
+                ),
+                status=201,
+                body="",
+            )
+        )
+
+        with mock.patch(
+            "core.api.viewsets_caldav.get_user_entitlements",
+            side_effect=EntitlementsUnavailableError("unavailable"),
+        ):
+            response = client.generic(
+                "MOVE",
+                "/caldav/calendars/users/test@example.com/cal-a/event-uid.ics",
+                HTTP_DESTINATION=(
+                    "http://example/caldav/calendars/users/test@example.com/"
+                    "cal-b/event-uid.ics"
+                ),
+            )
+
+        assert response.status_code == 201
+        assert len(responses.calls) == 1
+
+    @responses.activate
     def test_object_delete_does_not_check_entitlement(self):
         """DELETE on an event (path ending .ics) is NOT gated by
         entitlements — only the calendar lifecycle is. Removing one's

--- a/src/backend/core/tests/test_entitlements.py
+++ b/src/backend/core/tests/test_entitlements.py
@@ -461,6 +461,64 @@ class TestCalDAVProxyEntitlements:  # pylint: disable=no-member
         assert len(responses.calls) == 1
 
     @responses.activate
+    def test_collection_delete_blocked_when_not_entitled(self):
+        """DELETE on a calendar collection (path ending /) requires the
+        same entitlement as MKCALENDAR — calendar lifecycle is symmetric.
+        """
+        user = factories.UserFactory(email="test@example.com")
+        client = APIClient()
+        client.force_login(user)
+
+        with mock.patch(
+            "core.api.viewsets_caldav.get_user_entitlements",
+            return_value={"can_access": False},
+        ):
+            response = client.generic(
+                "DELETE",
+                "/caldav/calendars/users/test@example.com/cal-id/",
+            )
+
+        assert response.status_code == HTTP_403_FORBIDDEN
+
+    @responses.activate
+    def test_object_delete_does_not_check_entitlement(self):
+        """DELETE on an event (path ending .ics) is NOT gated by
+        entitlements — only the calendar lifecycle is. Removing one's
+        own events must always work, regardless of subscription state.
+        """
+        user = factories.UserFactory(email="test@example.com")
+        client = APIClient()
+        client.force_login(user)
+
+        caldav_url = settings.CALDAV_URL
+        responses.add(
+            responses.Response(
+                method="DELETE",
+                url=(
+                    f"{caldav_url}/caldav/calendars/users/test@example.com/"
+                    "cal-id/event-uid.ics"
+                ),
+                status=204,
+                body="",
+            )
+        )
+
+        # No entitlement mock — and the request must succeed even if the
+        # service is unreachable. Patching to raise would prove the
+        # check is bypassed for object DELETE.
+        with mock.patch(
+            "core.api.viewsets_caldav.get_user_entitlements",
+            side_effect=EntitlementsUnavailableError("unavailable"),
+        ):
+            response = client.generic(
+                "DELETE",
+                ("/caldav/calendars/users/test@example.com/cal-id/event-uid.ics"),
+            )
+
+        assert response.status_code == 204
+        assert len(responses.calls) == 1
+
+    @responses.activate
     def test_propfind_allowed_when_not_entitled(self):
         """PROPFIND should work for non-entitled users (shared calendars)."""
         user = factories.UserFactory(email="test@example.com")

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/hooks/useSchedulerHandlers.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/hooks/useSchedulerHandlers.ts
@@ -18,6 +18,7 @@ import type {
 } from "../../../services/dav/types/event-calendar";
 import type { EventCalendarAdapter, CalDavExtendedProps } from "../../../services/dav/EventCalendarAdapter";
 import type { CalDavService } from "../../../services/dav/CalDavService";
+import { getCalendarUrlFromEventUrl } from "../../../services/dav/caldav-helpers";
 import type {
   EventModalState,
   RecurringDeleteOption,
@@ -460,10 +461,34 @@ export const useSchedulerHandlers = ({
           etag = fetchResult.data.etag;
         }
 
+        const sourceCalendarUrl = getCalendarUrlFromEventUrl(modalState.eventUrl);
+
+        // Calendar change: WebDAV MOVE relocates the resource without firing
+        // iTIP (Sabre's Schedule plugin skips it on MOVE), so attendees don't
+        // get spurious REQUEST/CANCEL emails. Then a normal PUT at the new
+        // URL applies any content edits — iTIP dispatches only on a
+        // significant change, as it would for any in-place edit.
+        let updateUrl = modalState.eventUrl;
+        let updateEtag = etag;
+        if (sourceCalendarUrl !== targetCalendarUrl) {
+          const moveResult = await caldavService.moveEvent({
+            sourceEventUrl: modalState.eventUrl,
+            targetCalendarUrl,
+            sourceEtag: etag,
+          });
+
+          if (!moveResult.success || !moveResult.data) {
+            throw new Error(moveResult.error || "Failed to move event");
+          }
+
+          updateUrl = moveResult.data.url;
+          updateEtag = moveResult.data.etag;
+        }
+
         const result = await caldavService.updateEvent({
-          eventUrl: modalState.eventUrl,
+          eventUrl: updateUrl,
           event: eventToUpdate,
-          etag,
+          etag: updateEtag,
         });
 
         if (!result.success) {

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/CalDavService.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/CalDavService.ts
@@ -1104,9 +1104,16 @@ export class CalDavService {
     const sourceCalendar = this._calendars.get(sourceCalendarUrl)
 
     return withErrorHandling(async () => {
-      const filename = params.sourceEventUrl.split('/').pop()
-      if (!filename) {
-        throw new Error('Could not derive filename from source event URL')
+      // Strip trailing slashes before splitting so a stray collection-shaped
+      // URL (ends with `/`) doesn't yield an empty filename that we'd then
+      // concatenate onto the target — producing the target collection URL
+      // as the destination. Also require the `.ics` suffix so only event
+      // resources are moveable through this path; the proxy and SabreDAV
+      // would reject a collection-targeted MOVE anyway, but failing here
+      // is louder and avoids a misleading server error.
+      const filename = params.sourceEventUrl.replace(/\/+$/, '').split('/').pop()
+      if (!filename || !filename.endsWith('.ics')) {
+        throw new Error('Could not derive event filename from source URL')
       }
       const newEventUrl = `${params.targetCalendarUrl}${filename}`
       const sourceEtag = params.sourceEtag ?? cachedSource?.etag

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/CalDavService.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/CalDavService.ts
@@ -1111,11 +1111,24 @@ export class CalDavService {
       const newEventUrl = `${params.targetCalendarUrl}${filename}`
       const sourceEtag = params.sourceEtag ?? cachedSource?.etag
 
-      const response = await fetch(params.sourceEventUrl, {
+      // The source calendar may not be in the cache (stale state, refresh
+      // race, or a source URL whose calendar key doesn't normalize to a
+      // cached entry). Fall back to the target calendar's auth/fetch
+      // settings so credentials are always sent — both calendars belong
+      // to the same CalDAV account, so the headers are interchangeable.
+      const fetchOptions = {
+        ...targetCalendar.fetchOptions,
         ...sourceCalendar?.fetchOptions,
+      }
+      const authHeaders = {
+        ...targetCalendar.headers,
+        ...sourceCalendar?.headers,
+      }
+      const response = await fetch(params.sourceEventUrl, {
+        ...fetchOptions,
         method: 'MOVE',
         headers: {
-          ...sourceCalendar?.headers,
+          ...authHeaders,
           Destination: newEventUrl,
           Overwrite: 'F',
           ...(sourceEtag ? { 'If-Match': sourceEtag } : {}),

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/CalDavService.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/CalDavService.ts
@@ -36,6 +36,7 @@ import type {
   CalDavEvent,
   CalDavEventCreate,
   CalDavEventUpdate,
+  CalDavEventMove,
   EventFilter,
   CalDavShareInvite,
   CalDavShareResponse,
@@ -1074,6 +1075,71 @@ export class CalDavService {
       this._events.set(updatedEvent.url, updatedEvent)
       return updatedEvent
     }, 'Failed to update event')
+  }
+
+  /**
+   * Relocate an event resource to a different calendar via WebDAV MOVE.
+   *
+   * SabreDAV's Schedule\Plugin skips iTIP dispatch on MOVE (CalDAV/Schedule/
+   * Plugin.php#beforeUnbind), which is the desired behavior when an organizer
+   * moves an event between their own calendars: attendees should not receive
+   * spurious REQUEST/CANCEL emails. Content edits (which may warrant iTIP)
+   * should be applied via a follow-up updateEvent at the returned URL — the
+   * `significantChange` filter then decides whether to notify attendees.
+   *
+   * Returns the new resource URL and ETag. Source ETag, if provided, is sent
+   * as If-Match for an optimistic-concurrency precondition.
+   */
+  async moveEvent(
+    params: CalDavEventMove,
+  ): Promise<CalDavResponse<{ url: string; etag?: string }>> {
+    const targetCalendar = this._calendars.get(params.targetCalendarUrl)
+    if (!targetCalendar) {
+      return { success: false, error: 'Target calendar not found' }
+    }
+
+    const cachedSource = this._events.get(params.sourceEventUrl)
+    const sourceCalendarUrl =
+      cachedSource?.calendarUrl ?? getCalendarUrlFromEventUrl(params.sourceEventUrl)
+    const sourceCalendar = this._calendars.get(sourceCalendarUrl)
+
+    return withErrorHandling(async () => {
+      const filename = params.sourceEventUrl.split('/').pop()
+      if (!filename) {
+        throw new Error('Could not derive filename from source event URL')
+      }
+      const newEventUrl = `${params.targetCalendarUrl}${filename}`
+      const sourceEtag = params.sourceEtag ?? cachedSource?.etag
+
+      const response = await fetch(params.sourceEventUrl, {
+        ...sourceCalendar?.fetchOptions,
+        method: 'MOVE',
+        headers: {
+          ...sourceCalendar?.headers,
+          Destination: newEventUrl,
+          Overwrite: 'F',
+          ...(sourceEtag ? { 'If-Match': sourceEtag } : {}),
+        },
+      })
+
+      if (!response.ok) {
+        throw new Error(`Failed to move event: ${response.status}`)
+      }
+
+      const newEtag = response.headers.get('etag') ?? undefined
+
+      if (cachedSource) {
+        this._events.delete(params.sourceEventUrl)
+        this._events.set(newEventUrl, {
+          ...cachedSource,
+          url: newEventUrl,
+          calendarUrl: params.targetCalendarUrl,
+          etag: newEtag,
+        })
+      }
+
+      return { url: newEventUrl, etag: newEtag }
+    }, 'Failed to move event')
   }
 
   async deleteEvent(eventUrl: string, etag?: string): Promise<CalDavResponse> {

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/__tests__/CalDavService.moveEvent.test.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/__tests__/CalDavService.moveEvent.test.ts
@@ -1,0 +1,118 @@
+/**
+ * CalDavService.moveEvent — auth-fallback regression test.
+ *
+ * The MOVE request is built with raw fetch (tsdav doesn't expose
+ * a high-level move helper), so it has to assemble auth headers and
+ * fetch options itself. If the source calendar isn't in the cache
+ * (refresh race, stale state, source URL whose calendar key doesn't
+ * normalize to a cached entry), the original spread-of-undefined
+ * implementation silently dropped Authorization and credentials,
+ * causing opaque 401s. moveEvent must fall back to the target
+ * calendar's headers/options — both belong to the same CalDAV
+ * account, so they're interchangeable.
+ */
+import { CalDavService } from '../CalDavService'
+
+type CalendarStubInit = {
+  url: string
+  headers?: Record<string, string>
+  fetchOptions?: RequestInit
+}
+
+function injectCalendar(svc: CalDavService, init: CalendarStubInit) {
+  // _calendars is private; we poke it directly because constructing a
+  // real one through connect() would require mocking the entire tsdav
+  // PROPFIND chain.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const calendars: Map<string, unknown> = (svc as any)._calendars
+  calendars.set(init.url, {
+    url: init.url,
+    headers: init.headers,
+    fetchOptions: init.fetchOptions,
+    // The remaining fields are unused by moveEvent but required by
+    // CalDavCalendar — leave as undefined.
+  })
+}
+
+describe('CalDavService.moveEvent — auth fallback', () => {
+  const originalFetch = globalThis.fetch
+  let fetchMock: jest.Mock
+
+  beforeEach(() => {
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      headers: new Headers({ etag: '"new-etag"' }),
+    })
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('falls back to target calendar headers when source is not cached', async () => {
+    const svc = new CalDavService()
+    const targetCalendarUrl = 'http://srv/cal/B/'
+    const sourceEventUrl = 'http://srv/cal/A/event-uid.ics'
+
+    // Only the target calendar is cached. The source calendar entry is
+    // missing — this is the failure mode we're testing.
+    injectCalendar(svc, {
+      url: targetCalendarUrl,
+      headers: { Authorization: 'Bearer target-token' },
+      fetchOptions: { credentials: 'include' as RequestCredentials },
+    })
+
+    const result = await svc.moveEvent({
+      sourceEventUrl,
+      targetCalendarUrl,
+      sourceEtag: '"src-etag"',
+    })
+
+    expect(result.success).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [calledUrl, init] = fetchMock.mock.calls[0]
+    expect(calledUrl).toBe(sourceEventUrl)
+    expect(init.method).toBe('MOVE')
+
+    // Auth must come through despite the missing source calendar entry.
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer target-token',
+      Destination: 'http://srv/cal/B/event-uid.ics',
+      Overwrite: 'F',
+      'If-Match': '"src-etag"',
+    })
+    expect(init.credentials).toBe('include')
+  })
+
+  it('uses source calendar headers when both source and target are cached, target only as fallback', async () => {
+    const svc = new CalDavService()
+    const sourceCalendarUrl = 'http://srv/cal/A/'
+    const targetCalendarUrl = 'http://srv/cal/B/'
+    const sourceEventUrl = `${sourceCalendarUrl}event-uid.ics`
+
+    injectCalendar(svc, {
+      url: targetCalendarUrl,
+      headers: { Authorization: 'Bearer target-token' },
+      fetchOptions: { credentials: 'include' as RequestCredentials },
+    })
+    injectCalendar(svc, {
+      url: sourceCalendarUrl,
+      headers: { Authorization: 'Bearer source-token' },
+      fetchOptions: { credentials: 'include' as RequestCredentials },
+    })
+
+    const result = await svc.moveEvent({
+      sourceEventUrl,
+      targetCalendarUrl,
+    })
+
+    expect(result.success).toBe(true)
+    const [, init] = fetchMock.mock.calls[0]
+    // Source headers win when both are present (per spread order:
+    // ...target, ...source). Target only fills gaps.
+    expect(init.headers.Authorization).toBe('Bearer source-token')
+  })
+})

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/types/caldav-service.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/types/caldav-service.ts
@@ -120,6 +120,12 @@ export type CalDavEventUpdate = {
   etag?: string
 }
 
+export type CalDavEventMove = {
+  sourceEventUrl: string
+  targetCalendarUrl: string
+  sourceEtag?: string
+}
+
 // ============================================================================
 // Time Range & Filters
 // ============================================================================


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-app support to move events between calendars.

* **Security & Stability**
  * Tightened entitlement checks for calendar management and destination access.
  * Hardened path validation to block traversal and encoded-URL attacks.
  * CalDAV/WebDAV cross-origin handling now advertises and accepts MOVE where applicable.

* **Tests**
  * Expanded server and client tests covering MOVE, allowlist enforcement, and traversal/destination protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->