### PR TITLE
✨(front) add calendars reordering + admin & layout fixes

### DIFF
--- a/src/backend/core/admin.py
+++ b/src/backend/core/admin.py
@@ -4,7 +4,10 @@ import secrets
 
 from django.contrib import admin
 from django.contrib.auth import admin as auth_admin
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
+from django.urls import path, reverse
 
 from . import models
 
@@ -121,12 +124,65 @@ class ChannelAdmin(admin.ModelAdmin):
         "last_used_at",
         "created_at",
     )
-    list_filter = ("type", "is_active")
+    list_filter = ("type", "scope_level", "is_active")
     search_fields = ("name", "user__email", "caldav_path")
     exclude = ("encrypted_settings",)
     readonly_fields = ("id", "created_at", "updated_at", "last_used_at")
     raw_id_fields = ("user", "organization")
     actions = ("regenerate_tokens",)
+    change_form_template = "admin/core/channel/change_form.html"
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "<uuid:object_id>/rotate-token/",
+                self.admin_site.admin_view(self.rotate_token_view),
+                name="core_channel_rotate_token",
+            ),
+        ]
+        return custom + urls
+
+    def rotate_token_view(self, request, object_id):
+        """Rotate a single channel's token from the change form button.
+
+        POST-only: rotating mutates state, so we don't expose a GET handler.
+        Renders the same success template as the bulk action so the new
+        token is shown exactly once.
+        """
+        if request.method != "POST":
+            return HttpResponseRedirect(
+                reverse("admin:core_channel_change", args=[object_id])
+            )
+        channel = get_object_or_404(models.Channel, pk=object_id)
+        token, password = self._rotate_one(channel)
+        context = {
+            **self.admin_site.each_context(request),
+            "title": "Regenerated channel tokens",
+            "results": [(channel, token, password)],
+        }
+        return TemplateResponse(
+            request, "admin/core/channel/regenerated_tokens.html", context
+        )
+
+    @staticmethod
+    def _rotate_one(channel):
+        """Mint a new token for one channel and return (token, caldav_password).
+
+        ``caldav_password`` is ``base64url(channel_id) + token`` for CalDAV
+        channels (the HTTP Basic Auth password), and ``None`` otherwise.
+        """
+        token = secrets.token_urlsafe(16)
+        channel.encrypted_settings = {
+            **channel.encrypted_settings,
+            "token": token,
+        }
+        channel.save(update_fields=["encrypted_settings", "updated_at"])
+        password = None
+        if channel.type == "caldav":
+            short_id = models.uuid_to_urlsafe(channel.pk)
+            password = f"{short_id}{token}"
+        return token, password
 
     @admin.action(description="Regenerate token for selected channels")
     def regenerate_tokens(self, request, queryset):
@@ -141,20 +197,7 @@ class ChannelAdmin(admin.ModelAdmin):
         (``base64url(channel_id)`` concatenated with ``token``) is shown
         alongside the raw token.
         """
-        results = []
-        for channel in queryset:
-            token = secrets.token_urlsafe(16)
-            channel.encrypted_settings = {
-                **channel.encrypted_settings,
-                "token": token,
-            }
-            channel.save(update_fields=["encrypted_settings", "updated_at"])
-            password = None
-            if channel.type == "caldav":
-                short_id = models.uuid_to_urlsafe(channel.pk)
-                password = f"{short_id}{token}"
-            results.append((channel, token, password))
-
+        results = [(channel, *self._rotate_one(channel)) for channel in queryset]
         context = {
             **self.admin_site.each_context(request),
             "title": "Regenerated channel tokens",

--- a/src/backend/core/templates/admin/core/channel/change_form.html
+++ b/src/backend/core/templates/admin/core/channel/change_form.html
@@ -1,0 +1,18 @@
+{% extends "admin/change_form.html" %}
+
+{% block object-tools-items %}
+  {% if original.pk %}
+    <li>
+      <form action="{% url 'admin:core_channel_rotate_token' original.pk %}"
+            method="post"
+            style="display:inline;"
+            onsubmit="return confirm('Rotate the token for this channel? The current token will be invalidated immediately.');">
+        {% csrf_token %}
+        <button type="submit" class="historylink" style="cursor:pointer;border:0;">
+          Rotate token
+        </button>
+      </form>
+    </li>
+  {% endif %}
+  {{ block.super }}
+{% endblock %}

--- a/src/backend/core/tests/conftest.py
+++ b/src/backend/core/tests/conftest.py
@@ -42,12 +42,19 @@ def truncate_caldav_tables(request, django_db_setup, django_db_blocker):  # pyli
     # Read from the environment so this stays in sync with the compose
     # config and can be overridden in CI without editing code.
     caldav_test_db = os.environ.get("CALDAV_TEST_DB", "caldav_test")
+    # SabreDAV tables live in a dedicated schema (CALDAV_DB_SCHEMA, set to
+    # "sabre" in env.d/development/caldav-test.defaults) so they don't
+    # share namespace with Django's `test_calendars` tables. Mirror that
+    # search_path here — otherwise the unqualified TRUNCATEs below fall
+    # back to "public" and fail with UndefinedTable.
+    caldav_test_schema = os.environ.get("CALDAV_DB_SCHEMA", "sabre")
     conn = psycopg.connect(
         host=db_settings["HOST"],
         port=db_settings["PORT"],
         dbname=caldav_test_db,
         user=db_settings["USER"],
         password=db_settings["PASSWORD"],
+        options=f"-c search_path={caldav_test_schema},public",
     )
     conn.autocommit = True
     try:

--- a/src/backend/core/tests/test_cross_org_e2e.py
+++ b/src/backend/core/tests/test_cross_org_e2e.py
@@ -2239,9 +2239,18 @@ class TestCalDAVProtocolSecurity:
             content_type="application/xml",
             HTTP_DEPTH="0",
         )
-        body = check.content.decode("utf-8", errors="ignore")
-        assert "calendar-order" in body
-        assert ">42<" in body
+        assert check.status_code == 207
+        ns = {"d": "DAV:", "a": "http://apple.com/ns/ical/"}
+        order_value = None
+        for response in ET.fromstring(check.content).findall("d:response", ns):
+            href_el = response.find("d:href", ns)
+            if href_el is None or not (href_el.text or "").rstrip("/").endswith(cal_id):
+                continue
+            order_el = response.find(".//a:calendar-order", ns)
+            if order_el is not None:
+                order_value = order_el.text
+                break
+        assert order_value == "42"
 
     def test_proppatch_calendar_order_overwrites(self):
         """Subsequent PROPPATCHes of calendar-order overwrite the prior value.
@@ -2277,10 +2286,18 @@ class TestCalDAVProtocolSecurity:
             content_type="application/xml",
             HTTP_DEPTH="0",
         )
-        body = check.content.decode("utf-8", errors="ignore")
-        assert ">300<" in body
-        assert ">100<" not in body
-        assert ">200<" not in body
+        assert check.status_code == 207
+        ns = {"d": "DAV:", "a": "http://apple.com/ns/ical/"}
+        order_value = None
+        for response in ET.fromstring(check.content).findall("d:response", ns):
+            href_el = response.find("d:href", ns)
+            if href_el is None or not (href_el.text or "").rstrip("/").endswith(cal_id):
+                continue
+            order_el = response.find(".//a:calendar-order", ns)
+            if order_el is not None:
+                order_value = order_el.text
+                break
+        assert order_value == "300"
 
 
 # ===================================================================

--- a/src/backend/core/tests/test_cross_org_e2e.py
+++ b/src/backend/core/tests/test_cross_org_e2e.py
@@ -2206,6 +2206,82 @@ class TestCalDAVProtocolSecurity:
         )
         assert "#e74c3c" in check.content.decode("utf-8", errors="ignore")
 
+    def test_proppatch_calendar_order_own_calendar(self):
+        """Owner can PROPPATCH ``{http://apple.com/ns/ical/}calendar-order``.
+
+        We rely on this property to persist the user's manual sidebar
+        ordering; the frontend writes it via PROPPATCH and reads it back
+        via PROPFIND. Sabre's PropertyStorage plugin handles it as a dead
+        property (no schema change), so this test guards against
+        regressions if that plugin is ever reordered or removed.
+        """
+        org = factories.OrganizationFactory(external_id="proto-order")
+        owner, owner_client, cal_path = _create_user_with_calendar(org, "owner-order")
+        cal_id = _get_cal_id(cal_path)
+        cal_url = f"/caldav/calendars/users/{owner.email}/{cal_id}/"
+
+        resp = _proppatch(
+            owner_client,
+            cal_url,
+            "<A:calendar-order>42</A:calendar-order>",
+        )
+        assert resp.status_code == 207
+
+        check = owner_client.generic(
+            "PROPFIND",
+            cal_url,
+            data=(
+                '<?xml version="1.0"?>'
+                '<propfind xmlns="DAV:" xmlns:A="http://apple.com/ns/ical/">'
+                "<prop><A:calendar-order/></prop>"
+                "</propfind>"
+            ),
+            content_type="application/xml",
+            HTTP_DEPTH="0",
+        )
+        body = check.content.decode("utf-8", errors="ignore")
+        assert "calendar-order" in body
+        assert ">42<" in body
+
+    def test_proppatch_calendar_order_overwrites(self):
+        """Subsequent PROPPATCHes of calendar-order overwrite the prior value.
+
+        The move handler in the frontend rewrites the order of every
+        affected sibling on each reorder, so each calendar may receive
+        multiple PROPPATCHes in a short window. The latest value must win.
+        """
+        org = factories.OrganizationFactory(external_id="proto-order-up")
+        owner, owner_client, cal_path = _create_user_with_calendar(
+            org, "owner-order-up"
+        )
+        cal_id = _get_cal_id(cal_path)
+        cal_url = f"/caldav/calendars/users/{owner.email}/{cal_id}/"
+
+        for value in ("100", "200", "300"):
+            resp = _proppatch(
+                owner_client,
+                cal_url,
+                f"<A:calendar-order>{value}</A:calendar-order>",
+            )
+            assert resp.status_code == 207
+
+        check = owner_client.generic(
+            "PROPFIND",
+            cal_url,
+            data=(
+                '<?xml version="1.0"?>'
+                '<propfind xmlns="DAV:" xmlns:A="http://apple.com/ns/ical/">'
+                "<prop><A:calendar-order/></prop>"
+                "</propfind>"
+            ),
+            content_type="application/xml",
+            HTTP_DEPTH="0",
+        )
+        body = check.content.decode("utf-8", errors="ignore")
+        assert ">300<" in body
+        assert ">100<" not in body
+        assert ">200<" not in body
+
 
 # ===================================================================
 # ResourceAutoSchedulePlugin

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarItemMenu.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarItemMenu.tsx
@@ -18,6 +18,10 @@ export const CalendarItemMenu = ({
   onShare,
   onImport,
   onSubscription,
+  onMoveUp,
+  onMoveDown,
+  canMoveUp,
+  canMoveDown,
 }: CalendarItemMenuProps) => {
   const { t } = useTranslation();
 
@@ -54,6 +58,22 @@ export const CalendarItemMenu = ({
       });
     }
 
+    if (onMoveUp && canMoveUp) {
+      items.push({
+        label: t("calendar.list.moveUp"),
+        icon: <span className="material-icons">arrow_upward</span>,
+        callback: onMoveUp,
+      });
+    }
+
+    if (onMoveDown && canMoveDown) {
+      items.push({
+        label: t("calendar.list.moveDown"),
+        icon: <span className="material-icons">arrow_downward</span>,
+        callback: onMoveDown,
+      });
+    }
+
     items.push({
       label: t("calendar.list.delete"),
       icon: <span className="material-icons">delete</span>,
@@ -61,7 +81,18 @@ export const CalendarItemMenu = ({
     });
 
     return items;
-  }, [t, onEdit, onDelete, onShare, onImport, onSubscription]);
+  }, [
+    t,
+    onEdit,
+    onDelete,
+    onShare,
+    onImport,
+    onSubscription,
+    onMoveUp,
+    onMoveDown,
+    canMoveUp,
+    canMoveDown,
+  ]);
 
   return (
     <DropdownMenu options={options} isOpen={isOpen} onOpenChange={onOpenChange}>

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarItemMenu.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarItemMenu.tsx
@@ -20,8 +20,6 @@ export const CalendarItemMenu = ({
   onSubscription,
   onMoveUp,
   onMoveDown,
-  canMoveUp,
-  canMoveDown,
 }: CalendarItemMenuProps) => {
   const { t } = useTranslation();
 
@@ -58,7 +56,7 @@ export const CalendarItemMenu = ({
       });
     }
 
-    if (onMoveUp && canMoveUp) {
+    if (onMoveUp) {
       items.push({
         label: t("calendar.list.moveUp"),
         icon: <span className="material-icons">arrow_upward</span>,
@@ -66,7 +64,7 @@ export const CalendarItemMenu = ({
       });
     }
 
-    if (onMoveDown && canMoveDown) {
+    if (onMoveDown) {
       items.push({
         label: t("calendar.list.moveDown"),
         icon: <span className="material-icons">arrow_downward</span>,
@@ -81,18 +79,7 @@ export const CalendarItemMenu = ({
     });
 
     return items;
-  }, [
-    t,
-    onEdit,
-    onDelete,
-    onShare,
-    onImport,
-    onSubscription,
-    onMoveUp,
-    onMoveDown,
-    canMoveUp,
-    canMoveDown,
-  ]);
+  }, [t, onEdit, onDelete, onShare, onImport, onSubscription, onMoveUp, onMoveDown]);
 
   return (
     <DropdownMenu options={options} isOpen={isOpen} onOpenChange={onOpenChange}>

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarList.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarList.tsx
@@ -30,6 +30,7 @@ export const CalendarList = () => {
     createCalendar,
     updateCalendar,
     deleteCalendar,
+    moveCalendar,
     refreshCalendars,
     calendarRef,
     isLoading: isCalendarLoading,
@@ -129,6 +130,13 @@ export const CalendarList = () => {
     }
   }, [calendarRef]);
 
+  const handleMove = useCallback(
+    (calendar: CalDavCalendar, direction: "up" | "down") => {
+      void moveCalendar(calendar.url, direction);
+    },
+    [moveCalendar],
+  );
+
   return (
     <>
       <div className="calendar-list">
@@ -162,7 +170,7 @@ export const CalendarList = () => {
           </div>
           {isMyCalendarsExpanded && (
             <div className="calendar-list__items">
-              {ownedCalendars.map((calendar) => (
+              {ownedCalendars.map((calendar, idx) => (
                 <CalendarListItem
                   key={calendar.url}
                   calendar={calendar}
@@ -176,6 +184,9 @@ export const CalendarList = () => {
                   onShare={handleOpenShareModal}
                   onImport={handleOpenImportModal}
                   onSubscription={handleOpenSubscriptionModal}
+                  onMove={handleMove}
+                  canMoveUp={idx > 0}
+                  canMoveDown={idx < ownedCalendars.length - 1}
                   onCloseMenu={handleCloseMenu}
                 />
               ))}
@@ -207,7 +218,7 @@ export const CalendarList = () => {
             </div>
             {isSharedCalendarsExpanded && (
               <div className="calendar-list__items">
-                {sharedCalendars.map((calendar) => (
+                {sharedCalendars.map((calendar, idx) => (
                   <CalendarListItem
                     key={calendar.url}
                     calendar={calendar}
@@ -220,6 +231,9 @@ export const CalendarList = () => {
                     onDelete={handleOpenDeleteModal}
                     onImport={handleOpenImportModal}
                     onSubscription={handleOpenSubscriptionModal}
+                    onMove={handleMove}
+                    canMoveUp={idx > 0}
+                    canMoveDown={idx < sharedCalendars.length - 1}
                     onCloseMenu={handleCloseMenu}
                   />
                 ))}

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarList.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarList.tsx
@@ -8,6 +8,10 @@ import { useTranslation } from "react-i18next";
 
 import { useCalendarContext } from "../../contexts";
 import { setupCalendar } from "@/features/mailbox/api";
+import {
+  addToast,
+  ToasterItem,
+} from "@/features/ui/components/toaster/Toaster";
 
 import { CalendarModal } from "./CalendarModal";
 import { CalendarShareModal } from "./CalendarShareModal";
@@ -130,11 +134,37 @@ export const CalendarList = () => {
     }
   }, [calendarRef]);
 
-  const handleMove = useCallback(
-    (calendar: CalDavCalendar, direction: "up" | "down") => {
-      void moveCalendar(calendar.url, direction);
+  const handleMoveUp = useCallback(
+    (calendar: CalDavCalendar) => {
+      // moveCalendar resolves with `{success: false, error}` when any
+      // PROPPATCH fails — surface that to the user instead of swallowing
+      // it (and instead of leaving the visible state quietly stale).
+      void moveCalendar(calendar.url, "up").then((result) => {
+        if (!result.success) {
+          addToast(
+            <ToasterItem type="error" closeButton>
+              {result.error || t("calendar.error.fetchCalendars")}
+            </ToasterItem>,
+          );
+        }
+      });
     },
-    [moveCalendar],
+    [moveCalendar, t],
+  );
+
+  const handleMoveDown = useCallback(
+    (calendar: CalDavCalendar) => {
+      void moveCalendar(calendar.url, "down").then((result) => {
+        if (!result.success) {
+          addToast(
+            <ToasterItem type="error" closeButton>
+              {result.error || t("calendar.error.fetchCalendars")}
+            </ToasterItem>,
+          );
+        }
+      });
+    },
+    [moveCalendar, t],
   );
 
   return (
@@ -184,9 +214,10 @@ export const CalendarList = () => {
                   onShare={handleOpenShareModal}
                   onImport={handleOpenImportModal}
                   onSubscription={handleOpenSubscriptionModal}
-                  onMove={handleMove}
-                  canMoveUp={idx > 0}
-                  canMoveDown={idx < ownedCalendars.length - 1}
+                  onMoveUp={idx > 0 ? handleMoveUp : undefined}
+                  onMoveDown={
+                    idx < ownedCalendars.length - 1 ? handleMoveDown : undefined
+                  }
                   onCloseMenu={handleCloseMenu}
                 />
               ))}
@@ -231,9 +262,12 @@ export const CalendarList = () => {
                     onDelete={handleOpenDeleteModal}
                     onImport={handleOpenImportModal}
                     onSubscription={handleOpenSubscriptionModal}
-                    onMove={handleMove}
-                    canMoveUp={idx > 0}
-                    canMoveDown={idx < sharedCalendars.length - 1}
+                    onMoveUp={idx > 0 ? handleMoveUp : undefined}
+                    onMoveDown={
+                      idx < sharedCalendars.length - 1
+                        ? handleMoveDown
+                        : undefined
+                    }
                     onCloseMenu={handleCloseMenu}
                   />
                 ))}

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarListItem.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarListItem.tsx
@@ -24,6 +24,9 @@ export const CalendarListItem = ({
   onShare,
   onImport,
   onSubscription,
+  onMove,
+  canMoveUp,
+  canMoveDown,
   onCloseMenu,
 }: CalendarListItemProps) => {
   const { t } = useTranslation();
@@ -81,6 +84,10 @@ export const CalendarListItem = ({
           onSubscription={
             onSubscription ? () => onSubscription(calendar) : undefined
           }
+          onMoveUp={onMove ? () => onMove(calendar, "up") : undefined}
+          onMoveDown={onMove ? () => onMove(calendar, "down") : undefined}
+          canMoveUp={canMoveUp}
+          canMoveDown={canMoveDown}
         />
       </div>
     </div>

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarListItem.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/CalendarListItem.tsx
@@ -24,9 +24,8 @@ export const CalendarListItem = ({
   onShare,
   onImport,
   onSubscription,
-  onMove,
-  canMoveUp,
-  canMoveDown,
+  onMoveUp,
+  onMoveDown,
   onCloseMenu,
 }: CalendarListItemProps) => {
   const { t } = useTranslation();
@@ -84,10 +83,8 @@ export const CalendarListItem = ({
           onSubscription={
             onSubscription ? () => onSubscription(calendar) : undefined
           }
-          onMoveUp={onMove ? () => onMove(calendar, "up") : undefined}
-          onMoveDown={onMove ? () => onMove(calendar, "down") : undefined}
-          canMoveUp={canMoveUp}
-          canMoveDown={canMoveDown}
+          onMoveUp={onMoveUp ? () => onMoveUp(calendar) : undefined}
+          onMoveDown={onMoveDown ? () => onMoveDown(calendar) : undefined}
         />
       </div>
     </div>

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/types.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/types.ts
@@ -27,11 +27,9 @@ export interface CalendarItemMenuProps {
   onShare?: () => void;
   onImport?: () => void;
   onSubscription?: () => void;
-  /** Move callbacks are gated by their `can*` flags — undefined means hidden. */
+  /** Pass `undefined` when at the bucket boundary to hide the entry. */
   onMoveUp?: () => void;
   onMoveDown?: () => void;
-  canMoveUp?: boolean;
-  canMoveDown?: boolean;
 }
 
 /**
@@ -61,10 +59,9 @@ export interface CalendarListItemProps {
   onShare?: (calendar: CalDavCalendar) => void;
   onImport?: (calendar: CalDavCalendar) => void;
   onSubscription?: (calendar: CalDavCalendar) => void;
-  onMove?: (calendar: CalDavCalendar, direction: "up" | "down") => void;
-  /** False at the bucket boundary — the menu hides the corresponding entry. */
-  canMoveUp?: boolean;
-  canMoveDown?: boolean;
+  /** Pass `undefined` at the bucket boundary to hide the entry. */
+  onMoveUp?: (calendar: CalDavCalendar) => void;
+  onMoveDown?: (calendar: CalDavCalendar) => void;
   onCloseMenu: () => void;
 }
 

--- a/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/types.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/components/calendar-list/types.ts
@@ -27,6 +27,11 @@ export interface CalendarItemMenuProps {
   onShare?: () => void;
   onImport?: () => void;
   onSubscription?: () => void;
+  /** Move callbacks are gated by their `can*` flags — undefined means hidden. */
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  canMoveUp?: boolean;
+  canMoveDown?: boolean;
 }
 
 /**
@@ -56,6 +61,10 @@ export interface CalendarListItemProps {
   onShare?: (calendar: CalDavCalendar) => void;
   onImport?: (calendar: CalDavCalendar) => void;
   onSubscription?: (calendar: CalDavCalendar) => void;
+  onMove?: (calendar: CalDavCalendar, direction: "up" | "down") => void;
+  /** False at the bucket boundary — the menu hides the corresponding entry. */
+  canMoveUp?: boolean;
+  canMoveDown?: boolean;
   onCloseMenu: () => void;
 }
 

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/Scheduler.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/Scheduler.tsx
@@ -331,8 +331,17 @@ export const Scheduler = ({ defaultCalendarUrl }: SchedulerProps) => {
     [adapter, calendarUrl, calendarRef],
   );
 
+  // Mobile multi-day views use the library's native per-column headers
+  // (aligned with each day column, like desktop). The WeekDayBar — which
+  // shows a 7-day strip with the visible window highlighted — is kept for
+  // the single-day grid (where it doubles as a day picker) and for the
+  // list view (where it anchors the current day).
+  const showWeekDayBar =
+    isMobile &&
+    (currentView === "timeGridDay" || currentView === "listWeek");
+
   return (
-    <div className="scheduler">
+    <div className="scheduler" data-view={currentView}>
       {isMobile ? (
         <>
           <MobileToolbar
@@ -344,13 +353,15 @@ export const Scheduler = ({ defaultCalendarUrl }: SchedulerProps) => {
             onWeekNext={handleWeekNext}
             onTodayClick={handleTodayClick}
           />
-          <WeekDayBar
-            currentDate={currentDate}
-            currentView={currentView}
-            intlLocale={intlLocale}
-            weekDays={weekDays}
-            onDayClick={handleDayClick}
-          />
+          {showWeekDayBar && (
+            <WeekDayBar
+              currentDate={currentDate}
+              currentView={currentView}
+              intlLocale={intlLocale}
+              weekDays={weekDays}
+              onDayClick={handleDayClick}
+            />
+          )}
         </>
       ) : (
         <SchedulerToolbar

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/SchedulerToolbar.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/SchedulerToolbar.tsx
@@ -37,6 +37,11 @@ export const SchedulerToolbar = ({
         callback: () => handleViewChange("timeGridDay"),
       },
       {
+        value: "timeGridWorkWeek",
+        label: t("calendar.views.workWeek"),
+        callback: () => handleViewChange("timeGridWorkWeek"),
+      },
+      {
         value: "timeGridWeek",
         label: t("calendar.views.week"),
         callback: () => handleViewChange("timeGridWeek"),

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/hooks/useSchedulerInit.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/hooks/useSchedulerInit.ts
@@ -112,9 +112,15 @@ export const useSchedulerInit = ({
 
         // Custom views
         views: {
-          timeGridTwoDays: {
-            type: "timeGridDay",
-            duration: { days: 2 },
+          // Mon-Fri view: a normal week-grid with Sat/Sun hidden.
+          // Using hiddenDays (rather than duration: { days: 5 }) gives a
+          // week-aligned window — `next` always jumps a full week — and
+          // keeps the Monday start regardless of the user's locale's
+          // firstDay setting.
+          timeGridWorkWeek: {
+            type: "timeGridWeek",
+            hiddenDays: [0, 6],
+            firstDay: 1,
           },
         },
 

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/mobile/MobileToolbar.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/mobile/MobileToolbar.tsx
@@ -45,9 +45,14 @@ export const MobileToolbar = ({
         callback: () => handleViewChange("timeGridDay"),
       },
       {
-        value: "timeGridTwoDays",
-        label: t("calendar.views.mobile.twoDays"),
-        callback: () => handleViewChange("timeGridTwoDays"),
+        value: "timeGridWorkWeek",
+        label: t("calendar.views.mobile.workWeek"),
+        callback: () => handleViewChange("timeGridWorkWeek"),
+      },
+      {
+        value: "timeGridWeek",
+        label: t("calendar.views.mobile.week"),
+        callback: () => handleViewChange("timeGridWeek"),
       },
       {
         value: "listWeek",

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/mobile/WeekDayBar.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/mobile/WeekDayBar.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import type { WeekDayBarProps } from "../types";
-import { isSameDay, isWeekend, addDays } from "@/utils/date";
+import { isSameDay, isWeekend } from "@/utils/date";
 
 export const WeekDayBar = ({
   currentDate,
@@ -16,13 +16,10 @@ export const WeekDayBar = ({
     [intlLocale],
   );
 
-  const isTwoDays = currentView === "timeGridTwoDays";
-
+  // The WeekDayBar is only rendered for `timeGridDay` (where it doubles
+  // as a day picker) and `listWeek` (where it anchors today). Other
+  // mobile views use the library's native column headers instead.
   const isSelected = (date: Date): boolean => {
-    if (isTwoDays) {
-      const nextDay = addDays(currentDate, 1);
-      return isSameDay(date, currentDate) || isSameDay(date, nextDay);
-    }
     if (currentView === "timeGridDay") {
       return isSameDay(date, currentDate);
     }

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/scheduler-theme.scss
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/scheduler-theme.scss
@@ -3,6 +3,11 @@
 // Aligns @event-calendar/core with La Suite design system (Cunningham)
 // =============================================================================
 
+@use "sass:map";
+@use "@/styles/cunningham-tokens-sass" as *;
+
+$tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
+
 // -----------------------------------------------------------------------------
 // 1. CSS Variables - Map --ec-* to Cunningham tokens
 // -----------------------------------------------------------------------------
@@ -261,19 +266,21 @@
 }
 
 // -----------------------------------------------------------------------------
-// 9. Mobile adjustments — single-day view only.
-//
-// In the 1-day mobile view, the custom WeekDayBar above the grid replaces
-// the library's native day-name row, so we hide that row and the empty
-// top-left sidebar cell. The `.ec-all-day` lane is a sibling under
-// `.ec-header` and must stay visible — that's why the selectors target
-// direct children only.
-//
-// For multi-day mobile views (Work week / Week) the WeekDayBar is not
-// rendered; the native per-column headers stay so each header aligns
-// vertically with its day column, matching desktop.
+// 9. Mobile adjustments.
+// (a) 1-day view: hide the library's native day-name row and the empty
+//     top-left sidebar cell — the custom WeekDayBar above the grid plays
+//     that role instead. The `.ec-all-day` lane is a sibling under
+//     `.ec-header` and must stay visible, so the selectors target direct
+//     children only.
+// (b) Multi-day views (Work week / Week): the WeekDayBar is not rendered;
+//     the native per-column headers stay so each one aligns vertically
+//     with its day column, matching desktop.
+// (c) Today's day-of-month (all multi-day mobile views): marked with a
+//     brand-color pill drawn behind the digit so the layout stays pixel-
+//     stable (the desktop rule's border + extra padding would shift the
+//     column header by ~10 px).
 // -----------------------------------------------------------------------------
-@media (max-width: 768px) {
+@media (max-width: $tablet) {
   .scheduler[data-view="timeGridDay"] {
     .ec-header > .ec-sidebar,
     .ec-header > .ec-grid {
@@ -285,24 +292,44 @@
   // shift the column header layout) and mark today with a brand-color
   // pill drawn as a pseudo-element behind the digit. Same idiom as the
   // 1-day WeekDayBar selected day so the layout stays pixel-stable.
-  .ec-col-head.ec-today time .day-of-month {
-    padding: 3px 0 !important;
-    border-color: transparent !important;
-    position: relative;
-    color: var(--c--contextuals--content--semantic--neutral--on-neutral);
-    z-index: 1;
+  // The `time` element also gets a visually-hidden ", today" suffix so
+  // screen readers announce the today semantics — the library doesn't
+  // set aria-current on the header.
+  .ec-col-head.ec-today {
+    time {
+      .day-of-month {
+        padding: 3px 0 !important;
+        border-color: transparent !important;
+        position: relative;
+        color: var(--c--contextuals--content--semantic--neutral--on-neutral);
+        z-index: 1;
 
-    &::before {
-      content: "";
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      width: 26px;
-      height: 26px;
-      border-radius: 50%;
-      background: var(--c--contextuals--background--semantic--brand--primary);
-      z-index: -1;
+        &::before {
+          content: "";
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          width: 26px;
+          height: 26px;
+          border-radius: 50%;
+          background: var(--c--contextuals--background--semantic--brand--primary);
+          z-index: -1;
+        }
+      }
+
+      &::after {
+        content: ", today";
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
     }
   }
 }

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/scheduler-theme.scss
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/scheduler-theme.scss
@@ -261,10 +261,48 @@
 }
 
 // -----------------------------------------------------------------------------
-// 9. Mobile adjustments - Hide native day headers (WeekDayBar replaces them)
+// 9. Mobile adjustments — single-day view only.
+//
+// In the 1-day mobile view, the custom WeekDayBar above the grid replaces
+// the library's native day-name row, so we hide that row and the empty
+// top-left sidebar cell. The `.ec-all-day` lane is a sibling under
+// `.ec-header` and must stay visible — that's why the selectors target
+// direct children only.
+//
+// For multi-day mobile views (Work week / Week) the WeekDayBar is not
+// rendered; the native per-column headers stay so each header aligns
+// vertically with its day column, matching desktop.
 // -----------------------------------------------------------------------------
 @media (max-width: 768px) {
-  .ec-header {
-    display: none !important;
+  .scheduler[data-view="timeGridDay"] {
+    .ec-header > .ec-sidebar,
+    .ec-header > .ec-grid {
+      display: none !important;
+    }
+  }
+
+  // Today's day-of-month: drop the framed border + extra padding (they
+  // shift the column header layout) and mark today with a brand-color
+  // pill drawn as a pseudo-element behind the digit. Same idiom as the
+  // 1-day WeekDayBar selected day so the layout stays pixel-stable.
+  .ec-col-head.ec-today time .day-of-month {
+    padding: 3px 0 !important;
+    border-color: transparent !important;
+    position: relative;
+    color: var(--c--contextuals--content--semantic--neutral--on-neutral);
+    z-index: 1;
+
+    &::before {
+      content: "";
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 26px;
+      height: 26px;
+      border-radius: 50%;
+      background: var(--c--contextuals--background--semantic--brand--primary);
+      z-index: -1;
+    }
   }
 }

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/scheduler-theme.scss
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/scheduler-theme.scss
@@ -326,7 +326,7 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
         padding: 0;
         margin: -1px;
         overflow: hidden;
-        clip: rect(0, 0, 0, 0);
+        clip-path: inset(50%);
         white-space: nowrap;
         border: 0;
       }

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/types.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/types.ts
@@ -170,7 +170,11 @@ export interface SchedulerToolbarProps {
 /**
  * Mobile-specific view types.
  */
-export type MobileView = "timeGridDay" | "timeGridTwoDays" | "listWeek";
+export type MobileView =
+  | "timeGridDay"
+  | "timeGridWorkWeek"
+  | "timeGridWeek"
+  | "listWeek";
 
 /**
  * Props for the MobileToolbar component.

--- a/src/frontend/apps/calendars/src/features/calendar/components/scheduler/types.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/components/scheduler/types.ts
@@ -168,15 +168,6 @@ export interface SchedulerToolbarProps {
 }
 
 /**
- * Mobile-specific view types.
- */
-export type MobileView =
-  | "timeGridDay"
-  | "timeGridWorkWeek"
-  | "timeGridWeek"
-  | "listWeek";
-
-/**
  * Props for the MobileToolbar component.
  */
 export interface MobileToolbarProps {

--- a/src/frontend/apps/calendars/src/features/calendar/contexts/CalendarContext.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/contexts/CalendarContext.tsx
@@ -323,52 +323,76 @@ export const CalendarContextProvider = ({
     [caldavService],
   );
 
+  const movingRef = useRef(false);
   const moveCalendar = useCallback(
     async (
       calendarUrl: string,
       direction: "up" | "down",
     ): Promise<{ success: boolean; error?: string }> => {
-      // Pick the bucket the calendar lives in (owned vs shared). Moves
-      // are confined to the bucket the user sees on screen — the buckets
-      // render as separate sections, so cross-bucket reorder would be
-      // meaningless.
-      const bucket = ownedCalendars.some((c) => c.url === calendarUrl)
-        ? [...ownedCalendars]
-        : [...sharedCalendars];
-      const idx = bucket.findIndex((c) => c.url === calendarUrl);
-      if (idx === -1) {
-        return { success: false, error: "Calendar not found" };
+      // Re-entry guard: a second click while the first move's PROPPATCHes
+      // and refresh are still in flight would compute against stale state
+      // (the closure captures ownedCalendars/sharedCalendars at call time)
+      // and could swap the same pair twice or assign duplicate orders.
+      if (movingRef.current) {
+        return { success: false, error: "Move already in progress" };
       }
-      const swapWith = direction === "up" ? idx - 1 : idx + 1;
-      if (swapWith < 0 || swapWith >= bucket.length) {
-        return { success: false, error: "Out of bounds" };
-      }
-      [bucket[idx], bucket[swapWith]] = [bucket[swapWith], bucket[idx]];
-
-      // Rewrite the whole bucket as 0, 1, 2, … — small contiguous
-      // integers are the conventional values for this property, so the
-      // order stays consistent if a user reorders the same calendars in
-      // another CalDAV client. PROPPATCHes are skipped for calendars
-      // whose value already matches, so a single swap typically touches
-      // just the two moved siblings.
-      const updates: Promise<unknown>[] = [];
-      for (let i = 0; i < bucket.length; i++) {
-        if (bucket[i].order !== i) {
-          updates.push(
-            caldavService.updateCalendar(bucket[i].url, { order: i }),
-          );
-        }
-      }
+      movingRef.current = true;
       try {
-        await Promise.all(updates);
-        await refreshCalendars();
-        return { success: true };
-      } catch (error) {
-        console.error("Error moving calendar:", error);
-        return {
-          success: false,
-          error: error instanceof Error ? error.message : "Unknown error",
-        };
+        // Pick the bucket the calendar lives in (owned vs shared). Moves
+        // are confined to the bucket the user sees on screen — the
+        // buckets render as separate sections, so cross-bucket reorder
+        // would be meaningless.
+        const bucket = ownedCalendars.some((c) => c.url === calendarUrl)
+          ? [...ownedCalendars]
+          : [...sharedCalendars];
+        const idx = bucket.findIndex((c) => c.url === calendarUrl);
+        if (idx === -1) {
+          return { success: false, error: "Calendar not found" };
+        }
+        const swapWith = direction === "up" ? idx - 1 : idx + 1;
+        if (swapWith < 0 || swapWith >= bucket.length) {
+          return { success: false, error: "Out of bounds" };
+        }
+        [bucket[idx], bucket[swapWith]] = [bucket[swapWith], bucket[idx]];
+
+        // Rewrite the whole bucket as 0, 1, 2, … — small contiguous
+        // integers are the conventional values for this property, so
+        // the order stays consistent if a user reorders the same
+        // calendars in another CalDAV client. PROPPATCHes are skipped
+        // for calendars whose value already matches, so a single swap
+        // typically touches just the two moved siblings.
+        const updates: Promise<{ success: boolean; error?: string }>[] = [];
+        for (let i = 0; i < bucket.length; i++) {
+          if (bucket[i].order !== i) {
+            updates.push(
+              caldavService.updateCalendar(bucket[i].url, { order: i }),
+            );
+          }
+        }
+        try {
+          const results = await Promise.all(updates);
+          // updateCalendar reports CalDAV-level failures via `{success:
+          // false}` rather than throwing, so Promise.all alone wouldn't
+          // surface them. Bail out before refreshCalendars so the user
+          // sees the error and the visible state isn't quietly stale.
+          const failed = results.find((r) => !r.success);
+          if (failed) {
+            return {
+              success: false,
+              error: failed.error || "Failed to update calendar order",
+            };
+          }
+          await refreshCalendars();
+          return { success: true };
+        } catch (error) {
+          console.error("Error moving calendar:", error);
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : "Unknown error",
+          };
+        }
+      } finally {
+        movingRef.current = false;
       }
     },
     [caldavService, ownedCalendars, sharedCalendars, refreshCalendars],

--- a/src/frontend/apps/calendars/src/features/calendar/contexts/CalendarContext.tsx
+++ b/src/frontend/apps/calendars/src/features/calendar/contexts/CalendarContext.tsx
@@ -80,6 +80,10 @@ export interface CalendarContextType {
     email: string,
     privilege?: SharePrivilege,
   ) => Promise<{ success: boolean; error?: string }>;
+  moveCalendar: (
+    calendarUrl: string,
+    direction: "up" | "down",
+  ) => Promise<{ success: boolean; error?: string }>;
   goToDate: (date: Date) => void;
 }
 
@@ -123,8 +127,19 @@ export const CalendarContextProvider = ({
 
   const { ownedCalendars, sharedCalendars } = useMemo(() => {
     const homeUrl = caldavService.getAccount()?.homeUrl;
+    // Sort by `calendar-order` ascending (missing = end), tie-broken by
+    // displayName so the order is stable for never-reordered calendars.
+    const byOrder = (a: CalDavCalendar, b: CalDavCalendar) => {
+      const ao = a.order ?? Number.POSITIVE_INFINITY;
+      const bo = b.order ?? Number.POSITIVE_INFINITY;
+      if (ao !== bo) return ao - bo;
+      return a.displayName.localeCompare(b.displayName);
+    };
     if (!homeUrl) {
-      return { ownedCalendars: davCalendars, sharedCalendars: [] };
+      return {
+        ownedCalendars: [...davCalendars].sort(byOrder),
+        sharedCalendars: [],
+      };
     }
     const owned: CalDavCalendar[] = [];
     const shared: CalDavCalendar[] = [];
@@ -135,6 +150,8 @@ export const CalendarContextProvider = ({
         shared.push(cal);
       }
     }
+    owned.sort(byOrder);
+    shared.sort(byOrder);
     return { ownedCalendars: owned, sharedCalendars: shared };
   }, [davCalendars, caldavService]);
 
@@ -306,6 +323,57 @@ export const CalendarContextProvider = ({
     [caldavService],
   );
 
+  const moveCalendar = useCallback(
+    async (
+      calendarUrl: string,
+      direction: "up" | "down",
+    ): Promise<{ success: boolean; error?: string }> => {
+      // Pick the bucket the calendar lives in (owned vs shared). Moves
+      // are confined to the bucket the user sees on screen — the buckets
+      // render as separate sections, so cross-bucket reorder would be
+      // meaningless.
+      const bucket = ownedCalendars.some((c) => c.url === calendarUrl)
+        ? [...ownedCalendars]
+        : [...sharedCalendars];
+      const idx = bucket.findIndex((c) => c.url === calendarUrl);
+      if (idx === -1) {
+        return { success: false, error: "Calendar not found" };
+      }
+      const swapWith = direction === "up" ? idx - 1 : idx + 1;
+      if (swapWith < 0 || swapWith >= bucket.length) {
+        return { success: false, error: "Out of bounds" };
+      }
+      [bucket[idx], bucket[swapWith]] = [bucket[swapWith], bucket[idx]];
+
+      // Rewrite the whole bucket as 0, 1, 2, … — small contiguous
+      // integers are the conventional values for this property, so the
+      // order stays consistent if a user reorders the same calendars in
+      // another CalDAV client. PROPPATCHes are skipped for calendars
+      // whose value already matches, so a single swap typically touches
+      // just the two moved siblings.
+      const updates: Promise<unknown>[] = [];
+      for (let i = 0; i < bucket.length; i++) {
+        if (bucket[i].order !== i) {
+          updates.push(
+            caldavService.updateCalendar(bucket[i].url, { order: i }),
+          );
+        }
+      }
+      try {
+        await Promise.all(updates);
+        await refreshCalendars();
+        return { success: true };
+      } catch (error) {
+        console.error("Error moving calendar:", error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Unknown error",
+        };
+      }
+    },
+    [caldavService, ownedCalendars, sharedCalendars, refreshCalendars],
+  );
+
   const goToDate = useCallback((date: Date) => {
     if (calendarRef.current) {
       calendarRef.current.setOption("date", date);
@@ -395,6 +463,7 @@ export const CalendarContextProvider = ({
     updateCalendar,
     deleteCalendar,
     shareCalendar,
+    moveCalendar,
     goToDate,
   };
 

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/CalDavService.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/CalDavService.ts
@@ -69,6 +69,7 @@ import {
   parseSharePrivilege,
   parseInviteSharees,
   parseInviteOrganizerEmail,
+  parseCalendarOrder,
   getCalendarUrlFromEventUrl,
   withErrorHandling,
   type ShareeXmlParams,
@@ -229,19 +230,9 @@ export class CalDavService {
       ? displayname
       : (displayname as { _cdata?: string } | undefined)?._cdata ?? ''
 
-    // `calendar-order` arrives either as a number or as a numeric string
-    // depending on tsdav's xml-js heuristics (pure-digit text is
-    // auto-coerced to a JS number, anything else stays a string). Accept
-    // both; non-finite/non-numeric values fall through as undefined so
-    // sorting tie-breaks on displayName.
-    const rawOrder = (props as Record<string, unknown> | undefined)?.calendarOrder
-    let order: number | undefined
-    if (typeof rawOrder === 'number' && Number.isFinite(rawOrder)) {
-      order = rawOrder
-    } else if (typeof rawOrder === 'string') {
-      const n = Number.parseInt(rawOrder, 10)
-      if (Number.isFinite(n)) order = n
-    }
+    const order = parseCalendarOrder(
+      (props as Record<string, unknown> | undefined)?.calendarOrder,
+    )
 
     return {
       url,

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/CalDavService.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/CalDavService.ts
@@ -229,11 +229,26 @@ export class CalDavService {
       ? displayname
       : (displayname as { _cdata?: string } | undefined)?._cdata ?? ''
 
+    // `calendar-order` arrives either as a number or as a numeric string
+    // depending on tsdav's xml-js heuristics (pure-digit text is
+    // auto-coerced to a JS number, anything else stays a string). Accept
+    // both; non-finite/non-numeric values fall through as undefined so
+    // sorting tie-breaks on displayName.
+    const rawOrder = (props as Record<string, unknown> | undefined)?.calendarOrder
+    let order: number | undefined
+    if (typeof rawOrder === 'number' && Number.isFinite(rawOrder)) {
+      order = rawOrder
+    } else if (typeof rawOrder === 'string') {
+      const n = Number.parseInt(rawOrder, 10)
+      if (Number.isFinite(n)) order = n
+    }
+
     return {
       url,
       displayName,
       description: (props as Record<string, string | undefined> | undefined)?.calendarDescription,
       color: (props as Record<string, string | undefined> | undefined)?.calendarColor,
+      order,
       includeInAvailability: !isTransparent,
       ownerType,
       mailboxEmail,
@@ -332,6 +347,7 @@ export class CalDavService {
       || params.color !== undefined
       || params.timezone !== undefined
       || params.includeInAvailability !== undefined
+      || params.order !== undefined
     if (!hasProps) {
       return { success: false, error: 'No properties to update' }
     }

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/__tests__/caldav-helpers.test.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/__tests__/caldav-helpers.test.ts
@@ -18,6 +18,7 @@ import {
   buildSyncCollectionXml,
   buildPrincipalSearchXml,
   parseCalendarComponents,
+  parseCalendarOrder,
   parseDavErrorMessage,
   parseShareStatus,
   getCalendarUrlFromEventUrl,
@@ -393,6 +394,39 @@ describe('caldav-helpers', () => {
         }
         const result = parseCalendarComponents(input)
         expect(result).toEqual(['VEVENT'])
+      })
+    })
+
+    describe('parseCalendarOrder', () => {
+      // tsdav's xml-js parser auto-coerces pure-digit element text to a
+      // JS number — the actual bug that broke calendar reordering once.
+      it('returns a finite number unchanged', () => {
+        expect(parseCalendarOrder(0)).toBe(0)
+        expect(parseCalendarOrder(42)).toBe(42)
+        expect(parseCalendarOrder(-1)).toBe(-1)
+      })
+
+      it('parses an integer-shaped string', () => {
+        expect(parseCalendarOrder('0')).toBe(0)
+        expect(parseCalendarOrder('100')).toBe(100)
+      })
+
+      it('returns undefined for missing / nullish / wrong-typed input', () => {
+        expect(parseCalendarOrder(undefined)).toBeUndefined()
+        expect(parseCalendarOrder(null)).toBeUndefined()
+        expect(parseCalendarOrder({})).toBeUndefined()
+        expect(parseCalendarOrder([])).toBeUndefined()
+      })
+
+      it('returns undefined for non-finite numbers', () => {
+        expect(parseCalendarOrder(Number.NaN)).toBeUndefined()
+        expect(parseCalendarOrder(Number.POSITIVE_INFINITY)).toBeUndefined()
+        expect(parseCalendarOrder(Number.NEGATIVE_INFINITY)).toBeUndefined()
+      })
+
+      it('returns undefined for non-numeric strings', () => {
+        expect(parseCalendarOrder('')).toBeUndefined()
+        expect(parseCalendarOrder('abc')).toBeUndefined()
       })
     })
 

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/__tests__/caldav-helpers.test.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/__tests__/caldav-helpers.test.ts
@@ -409,6 +409,17 @@ describe('caldav-helpers', () => {
       it('parses an integer-shaped string', () => {
         expect(parseCalendarOrder('0')).toBe(0)
         expect(parseCalendarOrder('100')).toBe(100)
+        expect(parseCalendarOrder('-3')).toBe(-3)
+        expect(parseCalendarOrder('+5')).toBe(5)
+        expect(parseCalendarOrder('  42  ')).toBe(42)
+      })
+
+      it('rejects strings with trailing junk', () => {
+        // Number.parseInt would happily eat the prefix and return 10;
+        // the full-match guard prevents that.
+        expect(parseCalendarOrder('10abc')).toBeUndefined()
+        expect(parseCalendarOrder('1.5')).toBeUndefined()
+        expect(parseCalendarOrder('1 2')).toBeUndefined()
       })
 
       it('returns undefined for missing / nullish / wrong-typed input', () => {

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/caldav-helpers.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/caldav-helpers.ts
@@ -59,6 +59,12 @@ export type CalendarProps = {
   displayName?: string
   description?: string
   color?: string
+  /**
+   * `{http://apple.com/ns/ical/}calendar-order`. Integer used to manually
+   * sort calendars in the sidebar; stored as a dead property by Sabre's
+   * PropertyStorage.
+   */
+  order?: number
   components?: string[]
   /** schedule-calendar-transp: 'opaque' (counts as busy) or 'transparent' */
   scheduleTransp?: 'opaque' | 'transparent'
@@ -76,6 +82,9 @@ export function buildCalendarPropsXml(props: CalendarProps): string[] {
   }
   if (props.color !== undefined && props.color !== null && typeof props.color === 'string') {
     elements.push(xmlProp('A', 'calendar-color', props.color))
+  }
+  if (props.order !== undefined && props.order !== null && typeof props.order === 'number') {
+    elements.push(xmlProp('A', 'calendar-order', String(props.order)))
   }
   if (props.components && props.components.length > 0) {
     const comps = props.components.map((c) => `<C:comp name="${escapeXml(c)}"/>`).join('')
@@ -394,6 +403,7 @@ export const CALENDAR_PROPS = {
   [`${DAVNamespaceShort.CALDAV}:calendar-timezone`]: {},
   [`${DAVNamespaceShort.DAV}:displayname`]: {},
   [`${DAVNamespaceShort.CALDAV_APPLE}:calendar-color`]: {},
+  [`${DAVNamespaceShort.CALDAV_APPLE}:calendar-order`]: {},
   [`${DAVNamespaceShort.CALENDAR_SERVER}:getctag`]: {},
   [`${DAVNamespaceShort.DAV}:resourcetype`]: {},
   [`${DAVNamespaceShort.CALDAV}:supported-calendar-component-set`]: {},

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/caldav-helpers.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/caldav-helpers.ts
@@ -514,8 +514,14 @@ export function parseCalendarOrder(raw: unknown): number | undefined {
     return raw
   }
   if (typeof raw === 'string') {
-    const n = Number.parseInt(raw, 10)
-    if (Number.isFinite(n)) return n
+    // Require the entire (trimmed) string to be an optionally-signed
+    // integer — otherwise `Number.parseInt` would happily turn "10abc"
+    // into 10 and swallow attacker-supplied trailing junk.
+    const trimmed = raw.trim()
+    if (/^[+-]?\d+$/.test(trimmed)) {
+      const n = Number.parseInt(trimmed, 10)
+      if (Number.isFinite(n)) return n
+    }
   }
   return undefined
 }

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/caldav-helpers.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/caldav-helpers.ts
@@ -500,6 +500,26 @@ export async function executePropfind<T>(
 // Response Parsing Helpers
 // ============================================================================
 
+/**
+ * Coerce a parsed `calendar-order` PROPFIND value to an integer.
+ *
+ * tsdav's xml-js parser auto-coerces pure-digit element text to a JS
+ * `number`, while non-numeric text stays a `string`. Either shape can
+ * arrive depending on what the server stored. Anything else (nullish,
+ * object, NaN, ±Infinity) is treated as "no order set" so sorting can
+ * fall back to displayName.
+ */
+export function parseCalendarOrder(raw: unknown): number | undefined {
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    return raw
+  }
+  if (typeof raw === 'string') {
+    const n = Number.parseInt(raw, 10)
+    if (Number.isFinite(n)) return n
+  }
+  return undefined
+}
+
 /** Parse supported-calendar-component-set from PROPFIND response */
 export function parseCalendarComponents(supportedCalendarComponentSet: unknown): string[] | undefined {
   if (!supportedCalendarComponentSet) return undefined

--- a/src/frontend/apps/calendars/src/features/calendar/services/dav/types/caldav-service.ts
+++ b/src/frontend/apps/calendars/src/features/calendar/services/dav/types/caldav-service.ts
@@ -65,6 +65,12 @@ export type CalDavCalendar = Pick<DAVCalendar, 'url' | 'ctag' | 'syncToken' | 'c
   displayName: string
   description?: string
   color?: string
+  /**
+   * `{http://apple.com/ns/ical/}calendar-order`. Integer used to manually
+   * sort calendars in the sidebar. Undefined when the calendar has never
+   * been reordered.
+   */
+  order?: number
   /** Whether this calendar's events count toward freebusy (default: true) */
   includeInAvailability: boolean
   /** Owner principal type: "MAILBOX" for mailbox calendars, undefined otherwise */
@@ -102,6 +108,8 @@ export type CalDavCalendarUpdate = {
   timezone?: string
   /** Toggle whether this calendar counts toward freebusy/availability */
   includeInAvailability?: boolean
+  /** `calendar-order` for manual sidebar ordering. */
+  order?: number
 }
 
 // ============================================================================

--- a/src/frontend/apps/calendars/src/features/i18n/translations.json
+++ b/src/frontend/apps/calendars/src/features/i18n/translations.json
@@ -129,6 +129,7 @@
         },
         "views": {
           "day": "Day",
+          "workWeek": "Work week",
           "week": "Week",
           "month": "Month",
           "listDay": "Day list",
@@ -138,7 +139,8 @@
           "today": "Today",
           "mobile": {
             "oneDay": "One day",
-            "twoDays": "Two days",
+            "workWeek": "Work week",
+            "week": "Week",
             "list": "List",
             "noEvents": "No events"
           }
@@ -237,6 +239,8 @@
           "share": "Share",
           "import": "Import events",
           "subscription": "Subscription URL",
+          "moveUp": "Move up",
+          "moveDown": "Move down",
           "options": "Options"
         },
         "importEvents": {
@@ -1049,6 +1053,7 @@
         },
         "views": {
           "day": "Jour",
+          "workWeek": "Semaine ouvrée",
           "week": "Semaine",
           "month": "Mois",
           "listDay": "Liste jour",
@@ -1058,7 +1063,8 @@
           "today": "Aujourd'hui",
           "mobile": {
             "oneDay": "Un jour",
-            "twoDays": "2 jours",
+            "workWeek": "Semaine ouvrée",
+            "week": "Semaine",
             "list": "Liste",
             "noEvents": "Aucun événement"
           }
@@ -1157,6 +1163,8 @@
           "share": "Partager",
           "import": "Importer des événements",
           "subscription": "URL d'abonnement",
+          "moveUp": "Déplacer vers le haut",
+          "moveDown": "Déplacer vers le bas",
           "options": "Options"
         },
         "importEvents": {
@@ -1711,6 +1719,7 @@
         },
         "views": {
           "day": "Dag",
+          "workWeek": "Werkweek",
           "week": "Week",
           "month": "Maand",
           "listDay": "Dag lijst",
@@ -1720,7 +1729,8 @@
           "today": "Vandaag",
           "mobile": {
             "oneDay": "Een dag",
-            "twoDays": "Twee dagen",
+            "workWeek": "Werkweek",
+            "week": "Week",
             "list": "Lijst",
             "noEvents": "Geen evenementen"
           }
@@ -1819,6 +1829,8 @@
           "share": "Delen",
           "import": "Evenementen importeren",
           "subscription": "Abonnements-URL",
+          "moveUp": "Omhoog verplaatsen",
+          "moveDown": "Omlaag verplaatsen",
           "options": "Opties"
         },
         "importEvents": {

--- a/src/frontend/apps/calendars/src/pages/index.scss
+++ b/src/frontend/apps/calendars/src/pages/index.scss
@@ -99,6 +99,28 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
     .c__feedback__button {
       display: none;
     }
+
+    // Pull the hamburger (and the empty right slot, whose children are
+    // hidden on mobile elsewhere) out of flex flow so the logo sits at
+    // the geometric centre of the viewport. The ui-kit's default header
+    // uses justify-content: space-between, which on mobile centres the
+    // logo between the hamburger and the right slot — visibly offset to
+    // the right because the right slot has no content.
+    position: relative;
+    justify-content: center;
+
+    .c__header__toggle-menu,
+    .c__header__right {
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+    .c__header__toggle-menu {
+      left: 16px;
+    }
+    .c__header__right {
+      right: 16px;
+    }
   }
 }
 

--- a/src/frontend/apps/calendars/src/pages/index.scss
+++ b/src/frontend/apps/calendars/src/pages/index.scss
@@ -100,26 +100,26 @@ $tablet: map.get($themes, "default", "globals", "breakpoints", "tablet");
       display: none;
     }
 
-    // Pull the hamburger (and the empty right slot, whose children are
-    // hidden on mobile elsewhere) out of flex flow so the logo sits at
-    // the geometric centre of the viewport. The ui-kit's default header
-    // uses justify-content: space-between, which on mobile centres the
-    // logo between the hamburger and the right slot — visibly offset to
-    // the right because the right slot has no content.
+    // Pull the hamburger out of flex flow so the logo sits at the
+    // geometric centre of the viewport. The ui-kit's default header uses
+    // justify-content: space-between, which on mobile centres the logo
+    // between the hamburger and the right slot — visibly offset to the
+    // right because the right slot has no content. `.c__header__right`
+    // is hidden entirely on mobile (its children are already hidden by
+    // the rule earlier in this file); dropping its layout box too keeps
+    // the empty element from ever floating over the logo if something
+    // is later added to that slot.
     position: relative;
     justify-content: center;
 
-    .c__header__toggle-menu,
-    .c__header__right {
+    .c__header__toggle-menu {
       position: absolute;
+      left: 16px;
       top: 50%;
       transform: translateY(-50%);
     }
-    .c__header__toggle-menu {
-      left: 16px;
-    }
     .c__header__right {
-      right: 16px;
+      display: none;
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reorder calendars in the sidebar with move up/down actions; ordering is persisted.
  * Rotate individual channel tokens from the admin change form.
  * Added Work Week (Mon–Fri) calendar view.

* **UI/UX Improvements**
  * Improved mobile header layout and centered logo.
  * Enhanced mobile scheduler toolbar and weekday bar behavior; updated mobile “today” styling.
  * Added localized labels for work-week and move actions.

* **Tests**
  * Added CalDAV security tests for the calendar-order property.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/suitenumerique/calendars/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->