### PR TITLE
feat(emails+rsvp): card-based invitation/update/cancel/reply emails + /rsvp pages

### DIFF
--- a/src/backend/core/api/viewsets_rsvp.py
+++ b/src/backend/core/api/viewsets_rsvp.py
@@ -57,7 +57,6 @@ def _render_error(request, message, lang="en"):
             "error_title": t("rsvp.error.invalidLink", lang),
             "header_color": "#dc2626",
             "lang": lang,
-            "app_name": getattr(settings, "APP_NAME", "Calendars"),
         },
         status=400,
     )
@@ -160,8 +159,7 @@ class RSVPConfirmView(View):
                 "status_icon": PARTSTAT_ICONS[action],
                 "header_color": PARTSTAT_COLORS[action],
                 "submit_label": label,
-                "app_name": getattr(settings, "APP_NAME", "Calendars"),
-            },
+                },
         )
 
     def post(self, request):
@@ -201,8 +199,7 @@ class RSVPConfirmView(View):
                 "header_color": PARTSTAT_COLORS[action],
                 "event_summary": summary,
                 "lang": lang,
-                "app_name": getattr(settings, "APP_NAME", "Calendars"),
-            },
+                },
         )
 
 

--- a/src/backend/core/api/viewsets_rsvp.py
+++ b/src/backend/core/api/viewsets_rsvp.py
@@ -57,6 +57,7 @@ def _render_error(request, message, lang="en"):
             "error_title": t("rsvp.error.invalidLink", lang),
             "header_color": "#dc2626",
             "lang": lang,
+            "app_name": getattr(settings, "APP_NAME", "Calendars"),
         },
         status=400,
     )
@@ -159,6 +160,7 @@ class RSVPConfirmView(View):
                 "status_icon": PARTSTAT_ICONS[action],
                 "header_color": PARTSTAT_COLORS[action],
                 "submit_label": label,
+                "app_name": getattr(settings, "APP_NAME", "Calendars"),
             },
         )
 
@@ -199,6 +201,7 @@ class RSVPConfirmView(View):
                 "header_color": PARTSTAT_COLORS[action],
                 "event_summary": summary,
                 "lang": lang,
+                "app_name": getattr(settings, "APP_NAME", "Calendars"),
             },
         )
 

--- a/src/backend/core/api/viewsets_rsvp.py
+++ b/src/backend/core/api/viewsets_rsvp.py
@@ -159,7 +159,7 @@ class RSVPConfirmView(View):
                 "status_icon": PARTSTAT_ICONS[action],
                 "header_color": PARTSTAT_COLORS[action],
                 "submit_label": label,
-                },
+            },
         )
 
     def post(self, request):
@@ -199,7 +199,7 @@ class RSVPConfirmView(View):
                 "header_color": PARTSTAT_COLORS[action],
                 "event_summary": summary,
                 "lang": lang,
-                },
+            },
         )
 
 

--- a/src/backend/core/templates/emails/_invitation_layout.html
+++ b/src/backend/core/templates/emails/_invitation_layout.html
@@ -1,10 +1,11 @@
-{# Shared layout for calendar invitation / update / cancel / reply emails.
-   Email-client-safe: table-based, inline styles, no external CSS.
-   Blocks:
-     header_color  — background color of the header strip (default blue).
-     badge_color   — text color of the uppercase header badge (default light blue tint).
-     body          — the per-template body content (after the header, before the footer).
-#}<!doctype html>
+{% comment %}
+Shared layout for calendar invitation / update / cancel / reply emails.
+Email-client-safe: table-based, inline styles, no external CSS.
+Blocks:
+  header_color  — background color of the header strip (default blue).
+  badge_color   — text color of the uppercase header badge (default light blue tint).
+  body          — the per-template body content (after the header, before the footer).
+{% endcomment %}<!doctype html>
 <html lang="{{ lang|default:'en' }}">
 <head>
   <meta charset="UTF-8">

--- a/src/backend/core/templates/emails/_invitation_layout.html
+++ b/src/backend/core/templates/emails/_invitation_layout.html
@@ -1,0 +1,65 @@
+{# Shared layout for calendar invitation / update / cancel / reply emails.
+   Email-client-safe: table-based, inline styles, no external CSS.
+   Blocks:
+     header_color  — background color of the header strip (default blue).
+     badge_color   — text color of the uppercase header badge (default light blue tint).
+     body          — the per-template body content (after the header, before the footer).
+#}<!doctype html>
+<html lang="{{ lang|default:'en' }}">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{ content.title }}</title>
+</head>
+<body style="margin:0; padding:0; background-color:#eef0f3;">
+  <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation"
+         width="100%" style="border-collapse:collapse; background-color:#eef0f3;">
+    <tr><td align="center" style="padding:24px 12px;">
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+             style="border-collapse:collapse; width:100%; max-width:560px;
+                    border-radius:8px; border:1px solid #d4d7dd; overflow:hidden;">
+
+        {# ── header ── #}
+        <tr><td style="background-color:{% block header_color %}#435de6{% endblock %}; padding:28px 36px;">
+          {% if content.badge %}
+          <p style="font-family:Arial,Helvetica,sans-serif; font-size:11px; font-weight:700;
+                    color:{% block badge_color %}#bdc6f6{% endblock %};
+                    text-transform:uppercase; letter-spacing:0.12em; margin:0 0 6px;">
+            {{ content.badge }}
+          </p>
+          {% endif %}
+          <p style="font-family:Arial,Helvetica,sans-serif; font-size:26px; font-weight:700;
+                    color:#ffffff; line-height:1.25; margin:0;">
+            {{ summary }}
+          </p>
+        </td></tr>
+
+        {# ── body (per-template) ── #}
+        <tr><td style="background-color:#f6f8f9; padding:28px 36px 32px;">
+          {% block body %}{% endblock %}
+        </td></tr>
+
+        {# ── divider ── #}
+        <tr><td style="background-color:#e7e9eb; height:1px; padding:0;
+                       font-size:0; line-height:0;"></td></tr>
+
+        {# ── footer ── #}
+        <tr><td style="background-color:#f6f8f9; padding:28px 36px;">
+          {% if instructions %}
+          <p style="font-family:Arial,Helvetica,sans-serif; font-size:12px;
+                    color:#626a80; line-height:1.6; margin:0 0 12px;">
+            {{ instructions }}
+          </p>
+          {% endif %}
+          <p style="font-family:Arial,Helvetica,sans-serif; font-size:12px;
+                    color:#626a80; line-height:1.6; margin:0;">
+            {{ footer }}
+          </p>
+        </td></tr>
+
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>

--- a/src/backend/core/templates/emails/calendar_invitation.html
+++ b/src/backend/core/templates/emails/calendar_invitation.html
@@ -1,158 +1,79 @@
-<!DOCTYPE html>
-<html lang="{{ lang }}">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ content.title }}</title>
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 600px;
-            margin: 0 auto;
-            padding: 20px;
-            background-color: #f5f5f5;
-        }
-        .container {
-            background-color: #ffffff;
-            border-radius: 8px;
-            padding: 30px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-        }
-        .header {
-            border-bottom: 2px solid #0066cc;
-            padding-bottom: 15px;
-            margin-bottom: 20px;
-        }
-        .header h1 {
-            color: #0066cc;
-            margin: 0;
-            font-size: 24px;
-        }
-        .event-title {
-            font-size: 20px;
-            font-weight: bold;
-            color: #333;
-            margin: 15px 0;
-        }
-        .event-details {
-            background-color: #f8f9fa;
-            border-left: 4px solid #0066cc;
-            padding: 15px;
-            margin: 20px 0;
-        }
-        .event-details table {
-            width: 100%;
-            border-collapse: collapse;
-        }
-        .event-details td {
-            padding: 8px 0;
-            vertical-align: top;
-        }
-        .event-details td:first-child {
-            font-weight: bold;
-            color: #666;
-            width: 120px;
-        }
-        .event-details td:last-child {
-            color: #333;
-        }
-        .description {
-            background-color: #fff;
-            border: 1px solid #eee;
-            padding: 15px;
-            margin: 20px 0;
-            border-radius: 4px;
-        }
-        .description h3 {
-            margin-top: 0;
-            color: #666;
-        }
-        .instructions {
-            background-color: #e7f3ff;
-            border-radius: 4px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-        .instructions p {
-            margin: 0;
-            color: #0066cc;
-        }
-        .footer {
-            border-top: 1px solid #eee;
-            padding-top: 15px;
-            margin-top: 20px;
-            font-size: 12px;
-            color: #999;
-            text-align: center;
-        }
-        .icon {
-            vertical-align: middle;
-            margin-right: 8px;
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <div class="header">
-            <h1>{{ content.heading }}</h1>
-        </div>
+{% extends "emails/_invitation_layout.html" %}
 
-        <p>{{ content.body }}</p>
+{# Header defaults (blue) inherited from the base layout. #}
 
-        <div class="event-title">{{ summary }}</div>
+{% block body %}
+  {# date/time #}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:18px; font-weight:700;
+            color:#1b1f2e; line-height:1.4; margin:0 0 4px;">
+    {{ start_date }}
+  </p>
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.4; margin:0 0 20px;">
+    {{ time_str }}{% if start_date != end_date %} · {{ labels.until }} {{ end_date }}{% endif %}
+  </p>
 
-        <div class="event-details">
-            <table>
-                <tr>
-                    <td>{{ labels.when }}</td>
-                    <td>
-                        {{ start_date }}<br>
-                        <strong>{{ time_str }}</strong>
-                        {% if start_date != end_date %}<br>{{ labels.until }} {{ end_date }}{% endif %}
-                    </td>
-                </tr>
-                {% if event.location %}
-                <tr>
-                    <td>{{ labels.location }}</td>
-                    <td>{{ event.location }}</td>
-                </tr>
-                {% endif %}
-                {% if event.url %}
-                <tr>
-                    <td>{{ labels.videoConference }}</td>
-                    <td><a href="{{ event.url }}" style="color: #0066cc;">{{ event.url }}</a></td>
-                </tr>
-                {% endif %}
-                <tr>
-                    <td>{{ labels.organizer }}</td>
-                    <td>{{ organizer_display }}</td>
-                </tr>
-            </table>
-        </div>
+  {% if event.location %}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.5; margin:0 0 10px;">
+    <strong style="color:#1b1f2e;">{{ labels.location }}:</strong> {{ event.location }}
+  </p>
+  {% endif %}
 
-        {% if event.description %}
-        <div class="description">
-            <h3>{{ labels.description }}</h3>
-            <p>{{ event.description|linebreaks }}</p>
-        </div>
-        {% endif %}
+  {% if event.url %}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.5; margin:0 0 10px;">
+    <strong style="color:#1b1f2e;">{{ labels.videoConference }}:</strong>
+    <a href="{{ event.url }}" style="color:#435de6; text-decoration:none;">{{ event.url }}</a>
+  </p>
+  {% endif %}
 
-        {% if rsvp_accepted_url %}
-        <div style="text-align: center; margin: 20px 0;">
-            <a href="{{ rsvp_accepted_url }}" style="display: inline-block; padding: 10px 24px; margin: 0 6px; background-color: #16a34a; color: white; text-decoration: none; border-radius: 6px; font-weight: bold;">{{ actions.accept }}</a>
-            <a href="{{ rsvp_tentative_url }}" style="display: inline-block; padding: 10px 24px; margin: 0 6px; background-color: #d97706; color: white; text-decoration: none; border-radius: 6px; font-weight: bold;">{{ actions.maybe }}</a>
-            <a href="{{ rsvp_declined_url }}" style="display: inline-block; padding: 10px 24px; margin: 0 6px; background-color: #dc2626; color: white; text-decoration: none; border-radius: 6px; font-weight: bold;">{{ actions.decline }}</a>
-        </div>
-        {% endif %}
-        <div class="instructions">
-            <p>{{ instructions }}</p>
-        </div>
+  {# organizer / body sentence (content.body is i18n-rendered with {{organizer}}) #}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.6; margin:0 0 24px;">
+    {{ content.body }}
+  </p>
 
-        <div class="footer">
-            <p>{{ footer }}</p>
-        </div>
-    </div>
-</body>
-</html>
+  {% if event.description %}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.6; margin:0 0 24px;">
+    {{ event.description|linebreaksbr }}
+  </p>
+  {% endif %}
+
+  {# RSVP buttons — only present for REQUEST-method emails #}
+  {% if rsvp_accepted_url %}
+  <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+         style="border-collapse:collapse; width:100%; table-layout:fixed;">
+    <tr>
+      <td style="padding:0 4px 0 0;">
+        <a href="{{ rsvp_accepted_url }}"
+           style="display:block; text-align:center; background-color:#435de6;
+                  color:#ffffff; font-family:Arial,Helvetica,sans-serif;
+                  font-size:14px; font-weight:700; padding:12px 8px;
+                  border-radius:4px; text-decoration:none;">
+          {{ actions.accept }}
+        </a>
+      </td>
+      <td style="padding:0 4px;">
+        <a href="{{ rsvp_tentative_url }}"
+           style="display:block; text-align:center; background-color:#626a80;
+                  color:#ffffff; font-family:Arial,Helvetica,sans-serif;
+                  font-size:14px; font-weight:700; padding:12px 8px;
+                  border-radius:4px; text-decoration:none;">
+          {{ actions.maybe }}
+        </a>
+      </td>
+      <td style="padding:0 0 0 4px;">
+        <a href="{{ rsvp_declined_url }}"
+           style="display:block; text-align:center; background-color:#d2212f;
+                  color:#ffffff; font-family:Arial,Helvetica,sans-serif;
+                  font-size:14px; font-weight:700; padding:12px 8px;
+                  border-radius:4px; text-decoration:none;">
+          {{ actions.decline }}
+        </a>
+      </td>
+    </tr>
+  </table>
+  {% endif %}
+{% endblock %}

--- a/src/backend/core/templates/emails/calendar_invitation_cancel.html
+++ b/src/backend/core/templates/emails/calendar_invitation_cancel.html
@@ -31,7 +31,9 @@
   {% if event.url %}
   <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
             line-height:1.5; margin:0 0 10px;">
-    <strong style="color:#1b1f2e;">{{ labels.videoConference }}:</strong> {{ event.url }}
+    <strong style="color:#1b1f2e;">{{ labels.videoConference }}:</strong>
+    <a href="{{ event.url }}" target="_blank" rel="noopener noreferrer"
+       style="color:#d2212f; text-decoration:none;">{{ event.url }}</a>
   </p>
   {% endif %}
 

--- a/src/backend/core/templates/emails/calendar_invitation_cancel.html
+++ b/src/backend/core/templates/emails/calendar_invitation_cancel.html
@@ -1,139 +1,42 @@
-<!DOCTYPE html>
-<html lang="{{ lang }}">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ content.title }}</title>
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 600px;
-            margin: 0 auto;
-            padding: 20px;
-            background-color: #f5f5f5;
-        }
-        .container {
-            background-color: #ffffff;
-            border-radius: 8px;
-            padding: 30px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-        }
-        .header {
-            border-bottom: 2px solid #dc3545;
-            padding-bottom: 15px;
-            margin-bottom: 20px;
-        }
-        .header h1 {
-            color: #dc3545;
-            margin: 0;
-            font-size: 24px;
-        }
-        .cancel-badge {
-            display: inline-block;
-            background-color: #dc3545;
-            color: white;
-            padding: 4px 12px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: bold;
-            margin-bottom: 10px;
-        }
-        .event-title {
-            font-size: 20px;
-            font-weight: bold;
-            color: #999;
-            margin: 15px 0;
-            text-decoration: line-through;
-        }
-        .event-details {
-            background-color: #f8d7da;
-            border-left: 4px solid #dc3545;
-            padding: 15px;
-            margin: 20px 0;
-        }
-        .event-details table {
-            width: 100%;
-            border-collapse: collapse;
-        }
-        .event-details td {
-            padding: 8px 0;
-            vertical-align: top;
-            color: #721c24;
-        }
-        .event-details td:first-child {
-            font-weight: bold;
-            width: 150px;
-        }
-        .instructions {
-            background-color: #f8d7da;
-            border-radius: 4px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-        .instructions p {
-            margin: 0;
-            color: #721c24;
-        }
-        .footer {
-            border-top: 1px solid #eee;
-            padding-top: 15px;
-            margin-top: 20px;
-            font-size: 12px;
-            color: #999;
-            text-align: center;
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <div class="header">
-            <h1>{{ content.heading }}</h1>
-        </div>
+{% extends "emails/_invitation_layout.html" %}
 
-        <span class="cancel-badge">{{ content.badge }}</span>
+{% block header_color %}#d2212f{% endblock %}
+{% block badge_color %}#f5c2c6{% endblock %}
 
-        <p>{{ content.body }}</p>
+{% block body %}
+  {# small label above the strikethrough date (cancelled event was scheduled for…) #}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:11px; font-weight:700;
+            color:#9b1c25; text-transform:uppercase; letter-spacing:0.12em;
+            margin:0 0 6px;">
+    {{ labels.wasScheduledFor }}
+  </p>
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:18px; font-weight:700;
+            color:#1b1f2e; line-height:1.4; margin:0 0 4px;
+            text-decoration:line-through; text-decoration-color:#d2212f;">
+    {{ start_date }}
+  </p>
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.4; margin:0 0 20px;
+            text-decoration:line-through; text-decoration-color:#d2212f;">
+    {{ time_str }}{% if start_date != end_date %} · {{ labels.until }} {{ end_date }}{% endif %}
+  </p>
 
-        <div class="event-title">{{ summary }}</div>
+  {% if event.location %}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.5; margin:0 0 10px;">
+    <strong style="color:#1b1f2e;">{{ labels.location }}:</strong> {{ event.location }}
+  </p>
+  {% endif %}
 
-        <div class="event-details">
-            <table>
-                <tr>
-                    <td>{{ labels.wasScheduledFor }}</td>
-                    <td>
-                        {{ start_date }}<br>
-                        <strong>{{ time_str }}</strong>
-                        {% if start_date != end_date %}<br>{{ labels.until }} {{ end_date }}{% endif %}
-                    </td>
-                </tr>
-                {% if event.location %}
-                <tr>
-                    <td>{{ labels.location }}</td>
-                    <td>{{ event.location }}</td>
-                </tr>
-                {% endif %}
-                {% if event.url %}
-                <tr>
-                    <td>{{ labels.videoConference }}</td>
-                    <td>{{ event.url }}</td>
-                </tr>
-                {% endif %}
-                <tr>
-                    <td>{{ labels.organizer }}</td>
-                    <td>{{ organizer_display }}</td>
-                </tr>
-            </table>
-        </div>
+  {% if event.url %}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.5; margin:0 0 10px;">
+    <strong style="color:#1b1f2e;">{{ labels.videoConference }}:</strong> {{ event.url }}
+  </p>
+  {% endif %}
 
-        <div class="instructions">
-            <p>{{ instructions }}</p>
-        </div>
-
-        <div class="footer">
-            <p>{{ footer }}</p>
-        </div>
-    </div>
-</body>
-</html>
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.6; margin:0 0 0;">
+    {{ content.body }}
+  </p>
+{% endblock %}

--- a/src/backend/core/templates/emails/calendar_invitation_reply.html
+++ b/src/backend/core/templates/emails/calendar_invitation_reply.html
@@ -1,126 +1,37 @@
-<!DOCTYPE html>
-<html lang="{{ lang }}">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ content.title }}</title>
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 600px;
-            margin: 0 auto;
-            padding: 20px;
-            background-color: #f5f5f5;
-        }
-        .container {
-            background-color: #ffffff;
-            border-radius: 8px;
-            padding: 30px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-        }
-        .header {
-            border-bottom: 2px solid #28a745;
-            padding-bottom: 15px;
-            margin-bottom: 20px;
-        }
-        .header h1 {
-            color: #28a745;
-            margin: 0;
-            font-size: 24px;
-        }
-        .event-title {
-            font-size: 20px;
-            font-weight: bold;
-            color: #333;
-            margin: 15px 0;
-        }
-        .event-details {
-            background-color: #d4edda;
-            border-left: 4px solid #28a745;
-            padding: 15px;
-            margin: 20px 0;
-        }
-        .event-details table {
-            width: 100%;
-            border-collapse: collapse;
-        }
-        .event-details td {
-            padding: 8px 0;
-            vertical-align: top;
-        }
-        .event-details td:first-child {
-            font-weight: bold;
-            color: #666;
-            width: 120px;
-        }
-        .instructions {
-            background-color: #d4edda;
-            border-radius: 4px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-        .instructions p {
-            margin: 0;
-            color: #155724;
-        }
-        .footer {
-            border-top: 1px solid #eee;
-            padding-top: 15px;
-            margin-top: 20px;
-            font-size: 12px;
-            color: #999;
-            text-align: center;
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <div class="header">
-            <h1>{{ content.heading }}</h1>
-        </div>
+{% extends "emails/_invitation_layout.html" %}
 
-        <p>{{ content.body }}</p>
+{% block header_color %}#16a34a{% endblock %}
+{% block badge_color %}#bbe5c5{% endblock %}
 
-        <div class="event-title">{{ summary }}</div>
+{% block body %}
+  {# date/time #}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:18px; font-weight:700;
+            color:#1b1f2e; line-height:1.4; margin:0 0 4px;">
+    {{ start_date }}
+  </p>
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.4; margin:0 0 20px;">
+    {{ time_str }}{% if start_date != end_date %} · {{ labels.until }} {{ end_date }}{% endif %}
+  </p>
 
-        <div class="event-details">
-            <table>
-                <tr>
-                    <td>{{ labels.when }}</td>
-                    <td>
-                        {{ start_date }}<br>
-                        <strong>{{ time_str }}</strong>
-                        {% if start_date != end_date %}<br>{{ labels.until }} {{ end_date }}{% endif %}
-                    </td>
-                </tr>
-                {% if event.location %}
-                <tr>
-                    <td>{{ labels.location }}</td>
-                    <td>{{ event.location }}</td>
-                </tr>
-                {% endif %}
-                {% if event.url %}
-                <tr>
-                    <td>{{ labels.videoConference }}</td>
-                    <td><a href="{{ event.url }}" style="color: #28a745;">{{ event.url }}</a></td>
-                </tr>
-                {% endif %}
-                <tr>
-                    <td>{{ labels.attendee }}</td>
-                    <td>{{ attendee_display }}</td>
-                </tr>
-            </table>
-        </div>
+  {% if event.location %}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.5; margin:0 0 10px;">
+    <strong style="color:#1b1f2e;">{{ labels.location }}:</strong> {{ event.location }}
+  </p>
+  {% endif %}
 
-        <div class="instructions">
-            <p>{{ instructions }}</p>
-        </div>
+  {% if event.url %}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.5; margin:0 0 10px;">
+    <strong style="color:#1b1f2e;">{{ labels.videoConference }}:</strong>
+    <a href="{{ event.url }}" style="color:#16a34a; text-decoration:none;">{{ event.url }}</a>
+  </p>
+  {% endif %}
 
-        <div class="footer">
-            <p>{{ footer }}</p>
-        </div>
-    </div>
-</body>
-</html>
+  {# attendee response sentence (content.body interpolates {{attendee}}) #}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.6; margin:0 0 0;">
+    {{ content.body }}
+  </p>
+{% endblock %}

--- a/src/backend/core/templates/emails/calendar_invitation_update.html
+++ b/src/backend/core/templates/emails/calendar_invitation_update.html
@@ -1,163 +1,77 @@
-<!DOCTYPE html>
-<html lang="{{ lang }}">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ content.title }}</title>
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 600px;
-            margin: 0 auto;
-            padding: 20px;
-            background-color: #f5f5f5;
-        }
-        .container {
-            background-color: #ffffff;
-            border-radius: 8px;
-            padding: 30px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-        }
-        .header {
-            border-bottom: 2px solid #ff9800;
-            padding-bottom: 15px;
-            margin-bottom: 20px;
-        }
-        .header h1 {
-            color: #ff9800;
-            margin: 0;
-            font-size: 24px;
-        }
-        .update-badge {
-            display: inline-block;
-            background-color: #ff9800;
-            color: white;
-            padding: 4px 12px;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: bold;
-            margin-bottom: 10px;
-        }
-        .event-title {
-            font-size: 20px;
-            font-weight: bold;
-            color: #333;
-            margin: 15px 0;
-        }
-        .event-details {
-            background-color: #fff8e1;
-            border-left: 4px solid #ff9800;
-            padding: 15px;
-            margin: 20px 0;
-        }
-        .event-details table {
-            width: 100%;
-            border-collapse: collapse;
-        }
-        .event-details td {
-            padding: 8px 0;
-            vertical-align: top;
-        }
-        .event-details td:first-child {
-            font-weight: bold;
-            color: #666;
-            width: 120px;
-        }
-        .description {
-            background-color: #fff;
-            border: 1px solid #eee;
-            padding: 15px;
-            margin: 20px 0;
-            border-radius: 4px;
-        }
-        .description h3 {
-            margin-top: 0;
-            color: #666;
-        }
-        .instructions {
-            background-color: #fff8e1;
-            border-radius: 4px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-        .instructions p {
-            margin: 0;
-            color: #e65100;
-        }
-        .footer {
-            border-top: 1px solid #eee;
-            padding-top: 15px;
-            margin-top: 20px;
-            font-size: 12px;
-            color: #999;
-            text-align: center;
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <div class="header">
-            <h1>{{ content.heading }}</h1>
-        </div>
+{% extends "emails/_invitation_layout.html" %}
 
-        <span class="update-badge">{{ content.badge }}</span>
+{# Header defaults (blue) inherited; content.badge resolves to "UPDATED" via i18n. #}
 
-        <p>{{ content.body }}</p>
+{% block body %}
+  {# date/time #}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:18px; font-weight:700;
+            color:#1b1f2e; line-height:1.4; margin:0 0 4px;">
+    {{ start_date }}
+  </p>
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.4; margin:0 0 20px;">
+    {{ time_str }}{% if start_date != end_date %} · {{ labels.until }} {{ end_date }}{% endif %}
+  </p>
 
-        <div class="event-title">{{ summary }}</div>
+  {% if event.location %}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.5; margin:0 0 10px;">
+    <strong style="color:#1b1f2e;">{{ labels.location }}:</strong> {{ event.location }}
+  </p>
+  {% endif %}
 
-        <div class="event-details">
-            <table>
-                <tr>
-                    <td>{{ labels.when }}</td>
-                    <td>
-                        {{ start_date }}<br>
-                        <strong>{{ time_str }}</strong>
-                        {% if start_date != end_date %}<br>{{ labels.until }} {{ end_date }}{% endif %}
-                    </td>
-                </tr>
-                {% if event.location %}
-                <tr>
-                    <td>{{ labels.location }}</td>
-                    <td>{{ event.location }}</td>
-                </tr>
-                {% endif %}
-                {% if event.url %}
-                <tr>
-                    <td>{{ labels.videoConference }}</td>
-                    <td><a href="{{ event.url }}" style="color: #e65100;">{{ event.url }}</a></td>
-                </tr>
-                {% endif %}
-                <tr>
-                    <td>{{ labels.organizer }}</td>
-                    <td>{{ organizer_display }}</td>
-                </tr>
-            </table>
-        </div>
+  {% if event.url %}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.5; margin:0 0 10px;">
+    <strong style="color:#1b1f2e;">{{ labels.videoConference }}:</strong>
+    <a href="{{ event.url }}" style="color:#435de6; text-decoration:none;">{{ event.url }}</a>
+  </p>
+  {% endif %}
 
-        {% if event.description %}
-        <div class="description">
-            <h3>{{ labels.description }}</h3>
-            <p>{{ event.description|linebreaks }}</p>
-        </div>
-        {% endif %}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.6; margin:0 0 24px;">
+    {{ content.body }}
+  </p>
 
-        {% if rsvp_accepted_url %}
-        <div style="text-align: center; margin: 20px 0;">
-            <a href="{{ rsvp_accepted_url }}" style="display: inline-block; padding: 10px 24px; margin: 0 6px; background-color: #16a34a; color: white; text-decoration: none; border-radius: 6px; font-weight: bold;">{{ actions.accept }}</a>
-            <a href="{{ rsvp_tentative_url }}" style="display: inline-block; padding: 10px 24px; margin: 0 6px; background-color: #d97706; color: white; text-decoration: none; border-radius: 6px; font-weight: bold;">{{ actions.maybe }}</a>
-            <a href="{{ rsvp_declined_url }}" style="display: inline-block; padding: 10px 24px; margin: 0 6px; background-color: #dc2626; color: white; text-decoration: none; border-radius: 6px; font-weight: bold;">{{ actions.decline }}</a>
-        </div>
-        {% endif %}
-        <div class="instructions">
-            <p>{{ instructions }}</p>
-        </div>
+  {% if event.description %}
+  <p style="font-family:Arial,Helvetica,sans-serif; font-size:14px; color:#626a80;
+            line-height:1.6; margin:0 0 24px;">
+    {{ event.description|linebreaksbr }}
+  </p>
+  {% endif %}
 
-        <div class="footer">
-            <p>{{ footer }}</p>
-        </div>
-    </div>
-</body>
-</html>
+  {% if rsvp_accepted_url %}
+  <table border="0" cellpadding="0" cellspacing="0" role="presentation"
+         style="border-collapse:collapse; width:100%; table-layout:fixed;">
+    <tr>
+      <td style="padding:0 4px 0 0;">
+        <a href="{{ rsvp_accepted_url }}"
+           style="display:block; text-align:center; background-color:#435de6;
+                  color:#ffffff; font-family:Arial,Helvetica,sans-serif;
+                  font-size:14px; font-weight:700; padding:12px 8px;
+                  border-radius:4px; text-decoration:none;">
+          {{ actions.accept }}
+        </a>
+      </td>
+      <td style="padding:0 4px;">
+        <a href="{{ rsvp_tentative_url }}"
+           style="display:block; text-align:center; background-color:#626a80;
+                  color:#ffffff; font-family:Arial,Helvetica,sans-serif;
+                  font-size:14px; font-weight:700; padding:12px 8px;
+                  border-radius:4px; text-decoration:none;">
+          {{ actions.maybe }}
+        </a>
+      </td>
+      <td style="padding:0 0 0 4px;">
+        <a href="{{ rsvp_declined_url }}"
+           style="display:block; text-align:center; background-color:#d2212f;
+                  color:#ffffff; font-family:Arial,Helvetica,sans-serif;
+                  font-size:14px; font-weight:700; padding:12px 8px;
+                  border-radius:4px; text-decoration:none;">
+          {{ actions.decline }}
+        </a>
+      </td>
+    </tr>
+  </table>
+  {% endif %}
+{% endblock %}

--- a/src/backend/core/templates/rsvp/_common_styles.html
+++ b/src/backend/core/templates/rsvp/_common_styles.html
@@ -1,5 +1,7 @@
-{# Shared CSS for rsvp/confirm.html and rsvp/response.html. Page-specific
-   styles (e.g. .submit-btn, .event-date) live in each template. #}
+{% comment %}
+  Shared CSS for rsvp/confirm.html and rsvp/response.html. Page-specific
+  styles (e.g. .submit-btn, .event-date) live in each template.
+{% endcomment %}
 <style>
   body { margin:0; padding:0; background-color:#eef0f3;
          font-family: Arial, Helvetica, sans-serif; color:#1b1f2e; }

--- a/src/backend/core/templates/rsvp/_common_styles.html
+++ b/src/backend/core/templates/rsvp/_common_styles.html
@@ -3,23 +3,33 @@
   styles (e.g. .submit-btn, .event-date) live in each template.
 {% endcomment %}
 <style>
-  body { margin:0; padding:0; background-color:#eef0f3;
-         font-family: Arial, Helvetica, sans-serif; color:#1b1f2e; }
+  :root {
+    --color-primary:     #435de6;
+    --color-bg:          #eef0f3;
+    --color-text:        #1b1f2e;
+    --color-muted:       #626a80;
+    --color-alert:       #d2212f;
+    --color-alert-text:  #f5c2c6;
+    --color-surface:     #f6f8f9;
+    --color-badge:       #bdc6f6;
+  }
+  body { margin:0; padding:0; background-color:var(--color-bg);
+         font-family: Arial, Helvetica, sans-serif; color:var(--color-text); }
   .wrap { padding:48px 16px; }
   .card { max-width:560px; margin:0 auto; border-radius:8px;
           border:1px solid #d4d7dd; overflow:hidden; background:#fff;
           box-shadow:0 1px 3px rgba(16,24,40,.04), 0 4px 16px rgba(16,24,40,.06); }
-  .header     { padding:28px 36px; background-color:#435de6; }
-  .header.err { background-color:#d2212f; }
-  .badge      { font-size:11px; font-weight:700; color:#bdc6f6;
+  .header     { padding:28px 36px; background-color:var(--color-primary); }
+  .header.err { background-color:var(--color-alert); }
+  .badge      { font-size:11px; font-weight:700; color:var(--color-badge);
                 text-transform:uppercase; letter-spacing:0.12em; margin:0 0 6px; }
-  .badge.err  { color:#f5c2c6; }
+  .badge.err  { color:var(--color-alert-text); }
   .title      { font-size:24px; font-weight:700; color:#ffffff;
                 line-height:1.25; margin:0; word-break:break-word; }
-  .body       { background-color:#f6f8f9; padding:28px 36px; }
-  .body p     { font-size:14px; color:#626a80; line-height:1.6; margin:0; }
+  .body       { background-color:var(--color-surface); padding:28px 36px; }
+  .body p     { font-size:14px; color:var(--color-muted); line-height:1.6; margin:0; }
   .divider    { background-color:#e7e9eb; height:1px; padding:0;
                 font-size:0; line-height:0; }
-  .footer     { background-color:#f6f8f9; padding:18px 36px; text-align:center; }
-  .footer p   { font-size:12px; color:#626a80; line-height:1.6; margin:0; }
+  .footer     { background-color:var(--color-surface); padding:18px 36px; text-align:center; }
+  .footer p   { font-size:12px; color:var(--color-muted); line-height:1.6; margin:0; }
 </style>

--- a/src/backend/core/templates/rsvp/_common_styles.html
+++ b/src/backend/core/templates/rsvp/_common_styles.html
@@ -1,0 +1,23 @@
+{# Shared CSS for rsvp/confirm.html and rsvp/response.html. Page-specific
+   styles (e.g. .submit-btn, .event-date) live in each template. #}
+<style>
+  body { margin:0; padding:0; background-color:#eef0f3;
+         font-family: Arial, Helvetica, sans-serif; color:#1b1f2e; }
+  .wrap { padding:48px 16px; }
+  .card { max-width:560px; margin:0 auto; border-radius:8px;
+          border:1px solid #d4d7dd; overflow:hidden; background:#fff;
+          box-shadow:0 1px 3px rgba(16,24,40,.04), 0 4px 16px rgba(16,24,40,.06); }
+  .header     { padding:28px 36px; background-color:#435de6; }
+  .header.err { background-color:#d2212f; }
+  .badge      { font-size:11px; font-weight:700; color:#bdc6f6;
+                text-transform:uppercase; letter-spacing:0.12em; margin:0 0 6px; }
+  .badge.err  { color:#f5c2c6; }
+  .title      { font-size:24px; font-weight:700; color:#ffffff;
+                line-height:1.25; margin:0; word-break:break-word; }
+  .body       { background-color:#f6f8f9; padding:28px 36px; }
+  .body p     { font-size:14px; color:#626a80; line-height:1.6; margin:0; }
+  .divider    { background-color:#e7e9eb; height:1px; padding:0;
+                font-size:0; line-height:0; }
+  .footer     { background-color:#f6f8f9; padding:18px 36px; text-align:center; }
+  .footer p   { font-size:12px; color:#626a80; line-height:1.6; margin:0; }
+</style>

--- a/src/backend/core/templates/rsvp/confirm.html
+++ b/src/backend/core/templates/rsvp/confirm.html
@@ -5,30 +5,36 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ page_title }}</title>
   <style>
-    body { margin: 0; padding: 0; background-color: #eef0f3;
-           font-family: Arial, Helvetica, sans-serif; color: #1b1f2e; }
-    .wrap { padding: 48px 16px; }
-    .card { max-width: 560px; margin: 0 auto; border-radius: 8px;
-            border: 1px solid #d4d7dd; overflow: hidden; background: #fff; }
-    .header { background-color: {{ header_color }}; padding: 28px 36px; color: #fff;
-              text-align: center; }
-    .header .icon { font-size: 36px; line-height: 1; margin-bottom: 10px; }
-    .header h1 { font-size: 22px; font-weight: 700; line-height: 1.25;
-                 margin: 0; color: #fff; }
-    .body { background-color: #f6f8f9; padding: 28px 36px; text-align: center; }
-    .body p { font-size: 14px; color: #626a80; line-height: 1.6; margin: 0; }
-    .submit-btn { display: inline-block; padding: 12px 28px; margin-top: 16px;
-                  background-color: {{ header_color }}; color: #fff;
-                  border: none; border-radius: 4px; font-size: 14px;
-                  font-weight: 700; cursor: pointer; text-decoration: none; }
+    body { margin:0; padding:0; background-color:#eef0f3;
+           font-family: Arial, Helvetica, sans-serif; color:#1b1f2e; }
+    .wrap { padding:48px 16px; }
+    .card { max-width:560px; margin:0 auto; border-radius:8px;
+            border:1px solid #d4d7dd; overflow:hidden; background:#fff;
+            box-shadow:0 1px 3px rgba(16,24,40,.04), 0 4px 16px rgba(16,24,40,.06); }
+    .header { background-color:#435de6; padding:28px 36px; }
+    .badge  { font-size:11px; font-weight:700; color:#bdc6f6;
+              text-transform:uppercase; letter-spacing:0.12em; margin:0 0 6px; }
+    .title  { font-size:26px; font-weight:700; color:#ffffff;
+              line-height:1.25; margin:0; }
+    .body   { background-color:#f6f8f9; padding:28px 36px 32px;
+              text-align:center; }
+    .body p { font-size:14px; color:#626a80; line-height:1.6; margin:0; }
+    .submit-btn { display:inline-block; padding:12px 28px; margin-top:16px;
+                  background-color:#435de6; color:#fff; border:none;
+                  border-radius:4px; font-size:14px; font-weight:700;
+                  text-decoration:none; cursor:pointer; }
+    .divider { background-color:#e7e9eb; height:1px; padding:0;
+               font-size:0; line-height:0; }
+    .footer { background-color:#f6f8f9; padding:18px 36px; text-align:center; }
+    .footer p { font-size:12px; color:#626a80; line-height:1.6; margin:0; }
   </style>
 </head>
 <body>
   <div class="wrap">
     <div class="card">
       <div class="header">
-        <div class="icon">{{ status_icon|safe }}</div>
-        <h1>{{ heading }}</h1>
+        <p class="badge">{{ heading }}</p>
+        <p class="title">{{ submit_label }} {{ status_icon|safe }}</p>
       </div>
       <div class="body">
         <form id="rsvp-form" method="post" action="/rsvp/">
@@ -38,6 +44,10 @@
           </noscript>
           <p id="loading-msg">…</p>
         </form>
+      </div>
+      <div class="divider"></div>
+      <div class="footer">
+        <p>{{ app_name }}</p>
       </div>
     </div>
   </div>

--- a/src/backend/core/templates/rsvp/confirm.html
+++ b/src/backend/core/templates/rsvp/confirm.html
@@ -1,70 +1,46 @@
-<!DOCTYPE html>
-<html lang="{{ lang|default:'fr' }}">
+<!doctype html>
+<html lang="{{ lang|default:'en' }}">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ page_title }}</title>
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 600px;
-            margin: 0 auto;
-            padding: 20px;
-            background-color: #f5f5f5;
-        }
-        .container {
-            background-color: #ffffff;
-            border-radius: 8px;
-            padding: 30px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-            text-align: center;
-        }
-        .icon {
-            font-size: 48px;
-            margin-bottom: 16px;
-        }
-        h1 {
-            color: {{ header_color }};
-            font-size: 24px;
-            margin: 0 0 16px;
-        }
-        .message {
-            font-size: 16px;
-            color: #555;
-            margin-bottom: 24px;
-        }
-        .submit-btn {
-            display: inline-block;
-            padding: 12px 32px;
-            background-color: {{ header_color }};
-            color: white;
-            border: none;
-            border-radius: 6px;
-            font-size: 16px;
-            font-weight: bold;
-            cursor: pointer;
-        }
-        .submit-btn:hover {
-            opacity: 0.9;
-        }
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ page_title }}</title>
+  <style>
+    body { margin: 0; padding: 0; background-color: #eef0f3;
+           font-family: Arial, Helvetica, sans-serif; color: #1b1f2e; }
+    .wrap { padding: 48px 16px; }
+    .card { max-width: 560px; margin: 0 auto; border-radius: 8px;
+            border: 1px solid #d4d7dd; overflow: hidden; background: #fff; }
+    .header { background-color: {{ header_color }}; padding: 28px 36px; color: #fff;
+              text-align: center; }
+    .header .icon { font-size: 36px; line-height: 1; margin-bottom: 10px; }
+    .header h1 { font-size: 22px; font-weight: 700; line-height: 1.25;
+                 margin: 0; color: #fff; }
+    .body { background-color: #f6f8f9; padding: 28px 36px; text-align: center; }
+    .body p { font-size: 14px; color: #626a80; line-height: 1.6; margin: 0; }
+    .submit-btn { display: inline-block; padding: 12px 28px; margin-top: 16px;
+                  background-color: {{ header_color }}; color: #fff;
+                  border: none; border-radius: 4px; font-size: 14px;
+                  font-weight: 700; cursor: pointer; text-decoration: none; }
+  </style>
 </head>
 <body>
-    <div class="container">
+  <div class="wrap">
+    <div class="card">
+      <div class="header">
         <div class="icon">{{ status_icon|safe }}</div>
         <h1>{{ heading }}</h1>
+      </div>
+      <div class="body">
         <form id="rsvp-form" method="post" action="/rsvp/">
-            <input type="hidden" name="t" value="{{ token }}">
-            <noscript>
-                <button type="submit" class="submit-btn">{{ submit_label }}</button>
-            </noscript>
-            <p class="message" id="loading-msg">...</p>
+          <input type="hidden" name="t" value="{{ token }}">
+          <noscript>
+            <button type="submit" class="submit-btn">{{ submit_label }}</button>
+          </noscript>
+          <p id="loading-msg">…</p>
         </form>
+      </div>
     </div>
-    <script>
-        document.getElementById('rsvp-form').submit();
-    </script>
+  </div>
+  <script>document.getElementById('rsvp-form').submit();</script>
 </body>
 </html>

--- a/src/backend/core/templates/rsvp/confirm.html
+++ b/src/backend/core/templates/rsvp/confirm.html
@@ -4,29 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ page_title }}</title>
+  {% include "rsvp/_common_styles.html" %}
   <style>
-    body { margin:0; padding:0; background-color:#eef0f3;
-           font-family: Arial, Helvetica, sans-serif; color:#1b1f2e; }
-    .wrap { padding:48px 16px; }
-    .card { max-width:560px; margin:0 auto; border-radius:8px;
-            border:1px solid #d4d7dd; overflow:hidden; background:#fff;
-            box-shadow:0 1px 3px rgba(16,24,40,.04), 0 4px 16px rgba(16,24,40,.06); }
-    .header { background-color:#435de6; padding:28px 36px; }
-    .badge  { font-size:11px; font-weight:700; color:#bdc6f6;
-              text-transform:uppercase; letter-spacing:0.12em; margin:0 0 6px; }
-    .title  { font-size:26px; font-weight:700; color:#ffffff;
-              line-height:1.25; margin:0; }
-    .body   { background-color:#f6f8f9; padding:28px 36px 32px;
-              text-align:center; }
-    .body p { font-size:14px; color:#626a80; line-height:1.6; margin:0; }
+    /* confirm-specific: center the loading message + auto-submit button */
+    .body { text-align:center; }
     .submit-btn { display:inline-block; padding:12px 28px; margin-top:16px;
                   background-color:#435de6; color:#fff; border:none;
                   border-radius:4px; font-size:14px; font-weight:700;
                   text-decoration:none; cursor:pointer; }
-    .divider { background-color:#e7e9eb; height:1px; padding:0;
-               font-size:0; line-height:0; }
-    .footer { background-color:#f6f8f9; padding:18px 36px; text-align:center; }
-    .footer p { font-size:12px; color:#626a80; line-height:1.6; margin:0; }
   </style>
 </head>
 <body>
@@ -47,7 +32,7 @@
       </div>
       <div class="divider"></div>
       <div class="footer">
-        <p>{{ app_name }}</p>
+        <p>Calendars</p>
       </div>
     </div>
   </div>

--- a/src/backend/core/templates/rsvp/confirm.html
+++ b/src/backend/core/templates/rsvp/confirm.html
@@ -34,7 +34,7 @@
     <div class="card">
       <div class="header">
         <p class="badge">{{ heading }}</p>
-        <p class="title">{{ submit_label }} {{ status_icon|safe }}</p>
+        <p class="title">{{ submit_label }}</p>
       </div>
       <div class="body">
         <form id="rsvp-form" method="post" action="/rsvp/">

--- a/src/backend/core/templates/rsvp/response.html
+++ b/src/backend/core/templates/rsvp/response.html
@@ -1,76 +1,56 @@
-<!DOCTYPE html>
-<html lang="{{ lang|default:'fr' }}">
+<!doctype html>
+<html lang="{{ lang|default:'en' }}">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ page_title }}</title>
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 600px;
-            margin: 0 auto;
-            padding: 20px;
-            background-color: #f5f5f5;
-        }
-        .container {
-            background-color: #ffffff;
-            border-radius: 8px;
-            padding: 30px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-            text-align: center;
-        }
-        .icon {
-            font-size: 48px;
-            margin-bottom: 16px;
-        }
-        h1 {
-            color: {{ header_color }};
-            font-size: 24px;
-            margin: 0 0 16px;
-        }
-        .message {
-            font-size: 16px;
-            color: #555;
-            margin-bottom: 24px;
-        }
-        .event-title {
-            font-size: 18px;
-            font-weight: bold;
-            color: #333;
-            margin: 16px 0;
-        }
-        .event-date {
-            color: #666;
-            margin-bottom: 24px;
-        }
-        .error-container {
-            background-color: #ffffff;
-            border-radius: 8px;
-            padding: 30px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-            text-align: center;
-        }
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ page_title }}</title>
+  <style>
+    body { margin: 0; padding: 0; background-color: #eef0f3;
+           font-family: Arial, Helvetica, sans-serif; color: #1b1f2e; }
+    .wrap { padding: 48px 16px; }
+    .card { max-width: 560px; margin: 0 auto; border-radius: 8px;
+            border: 1px solid #d4d7dd; overflow: hidden; background: #fff; }
+    .header { padding: 28px 36px; color: #fff; text-align: center; }
+    .header.ok    { background-color: {{ header_color|default:"#435de6" }}; }
+    .header.err   { background-color: #d2212f; }
+    .header .icon { font-size: 40px; line-height: 1; margin-bottom: 10px; }
+    .header h1    { font-size: 22px; font-weight: 700; line-height: 1.25;
+                    margin: 0; color: #fff; }
+    .body { background-color: #f6f8f9; padding: 28px 36px; }
+    .event-title { font-family: Arial, Helvetica, sans-serif;
+                   font-size: 18px; font-weight: 700; color: #1b1f2e;
+                   line-height: 1.4; margin: 0 0 4px; text-align: center; }
+    .event-date  { font-family: Arial, Helvetica, sans-serif;
+                   font-size: 14px; color: #626a80; line-height: 1.4;
+                   margin: 0 0 20px; text-align: center; }
+    .message { font-family: Arial, Helvetica, sans-serif;
+               font-size: 14px; color: #626a80; line-height: 1.6;
+               margin: 0; text-align: center; }
+  </style>
 </head>
 <body>
-    <div class="container">
-        {% if error %}
+  <div class="wrap">
+    <div class="card">
+      {% if error %}
+      <div class="header err">
         <div class="icon">&#10060;</div>
-        <h1 style="color: #dc2626;">{{ error_title }}</h1>
+        <h1>{{ error_title }}</h1>
+      </div>
+      <div class="body">
         <p class="message">{{ error }}</p>
-        {% else %}
+      </div>
+      {% else %}
+      <div class="header ok">
         <div class="icon">{{ status_icon|safe }}</div>
         <h1>{{ heading }}</h1>
-        {% if event_summary %}
-        <div class="event-title">{{ event_summary }}</div>
-        {% endif %}
-        {% if event_date %}
-        <div class="event-date">{{ event_date }}</div>
-        {% endif %}
-        <p class="message">{{ message }}</p>
-        {% endif %}
+      </div>
+      <div class="body">
+        {% if event_summary %}<div class="event-title">{{ event_summary }}</div>{% endif %}
+        {% if event_date %}<div class="event-date">{{ event_date }}</div>{% endif %}
+        {% if message %}<p class="message">{{ message }}</p>{% endif %}
+      </div>
+      {% endif %}
     </div>
+  </div>
 </body>
 </html>

--- a/src/backend/core/templates/rsvp/response.html
+++ b/src/backend/core/templates/rsvp/response.html
@@ -4,31 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ page_title }}</title>
+  {% include "rsvp/_common_styles.html" %}
   <style>
-    body { margin:0; padding:0; background-color:#eef0f3;
-           font-family: Arial, Helvetica, sans-serif; color:#1b1f2e; }
-    .wrap { padding:48px 16px; }
-    .card { max-width:560px; margin:0 auto; border-radius:8px;
-            border:1px solid #d4d7dd; overflow:hidden; background:#fff;
-            box-shadow:0 1px 3px rgba(16,24,40,.04), 0 4px 16px rgba(16,24,40,.06); }
-    .header     { padding:28px 36px; }
-    .header.ok  { background-color:#435de6; }
-    .header.err { background-color:#d2212f; }
-    .badge      { font-size:11px; font-weight:700;
-                  text-transform:uppercase; letter-spacing:0.12em; margin:0 0 6px; }
-    .badge.ok   { color:#bdc6f6; }
-    .badge.err  { color:#f5c2c6; }
-    .title      { font-size:24px; font-weight:700; color:#ffffff;
-                  line-height:1.25; margin:0; word-break:break-word; }
-    .body       { background-color:#f6f8f9; padding:28px 36px 24px; text-align:center; }
-    .body .icon { font-size:36px; line-height:1; margin:0 0 12px; }
-    .body p     { font-size:14px; color:#626a80; line-height:1.6; margin:0; }
-    .body .event-date  { font-size:14px; color:#626a80; line-height:1.4;
-                         margin:0 0 12px; }
-    .divider    { background-color:#e7e9eb; height:1px; padding:0;
-                  font-size:0; line-height:0; }
-    .footer     { background-color:#f6f8f9; padding:18px 36px; text-align:center; }
-    .footer p   { font-size:12px; color:#626a80; line-height:1.6; margin:0; }
+    /* response-specific: centered body + optional event-date line */
+    .body { text-align:center; }
+    .body .event-date { font-size:14px; color:#626a80; line-height:1.4;
+                        margin:0 0 12px; }
   </style>
 </head>
 <body>
@@ -43,8 +24,8 @@
         <p>{{ error }}</p>
       </div>
       {% else %}
-      <div class="header ok">
-        <p class="badge ok">{{ heading }}</p>
+      <div class="header">
+        <p class="badge">{{ heading }}</p>
         <p class="title">{{ event_summary }}</p>
       </div>
       <div class="body">
@@ -54,7 +35,7 @@
       {% endif %}
       <div class="divider"></div>
       <div class="footer">
-        <p>{{ app_name }}</p>
+        <p>Calendars</p>
       </div>
     </div>
   </div>

--- a/src/backend/core/templates/rsvp/response.html
+++ b/src/backend/core/templates/rsvp/response.html
@@ -40,7 +40,6 @@
         <p class="title">{{ error_title }}</p>
       </div>
       <div class="body">
-        <div class="icon">&#10060;</div>
         <p>{{ error }}</p>
       </div>
       {% else %}
@@ -49,7 +48,6 @@
         <p class="title">{{ event_summary }}</p>
       </div>
       <div class="body">
-        {% if status_icon %}<div class="icon">{{ status_icon|safe }}</div>{% endif %}
         {% if event_date %}<div class="event-date">{{ event_date }}</div>{% endif %}
         {% if message %}<p>{{ message }}</p>{% endif %}
       </div>

--- a/src/backend/core/templates/rsvp/response.html
+++ b/src/backend/core/templates/rsvp/response.html
@@ -5,27 +5,30 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ page_title }}</title>
   <style>
-    body { margin: 0; padding: 0; background-color: #eef0f3;
-           font-family: Arial, Helvetica, sans-serif; color: #1b1f2e; }
-    .wrap { padding: 48px 16px; }
-    .card { max-width: 560px; margin: 0 auto; border-radius: 8px;
-            border: 1px solid #d4d7dd; overflow: hidden; background: #fff; }
-    .header { padding: 28px 36px; color: #fff; text-align: center; }
-    .header.ok    { background-color: {{ header_color|default:"#435de6" }}; }
-    .header.err   { background-color: #d2212f; }
-    .header .icon { font-size: 40px; line-height: 1; margin-bottom: 10px; }
-    .header h1    { font-size: 22px; font-weight: 700; line-height: 1.25;
-                    margin: 0; color: #fff; }
-    .body { background-color: #f6f8f9; padding: 28px 36px; }
-    .event-title { font-family: Arial, Helvetica, sans-serif;
-                   font-size: 18px; font-weight: 700; color: #1b1f2e;
-                   line-height: 1.4; margin: 0 0 4px; text-align: center; }
-    .event-date  { font-family: Arial, Helvetica, sans-serif;
-                   font-size: 14px; color: #626a80; line-height: 1.4;
-                   margin: 0 0 20px; text-align: center; }
-    .message { font-family: Arial, Helvetica, sans-serif;
-               font-size: 14px; color: #626a80; line-height: 1.6;
-               margin: 0; text-align: center; }
+    body { margin:0; padding:0; background-color:#eef0f3;
+           font-family: Arial, Helvetica, sans-serif; color:#1b1f2e; }
+    .wrap { padding:48px 16px; }
+    .card { max-width:560px; margin:0 auto; border-radius:8px;
+            border:1px solid #d4d7dd; overflow:hidden; background:#fff;
+            box-shadow:0 1px 3px rgba(16,24,40,.04), 0 4px 16px rgba(16,24,40,.06); }
+    .header     { padding:28px 36px; }
+    .header.ok  { background-color:#435de6; }
+    .header.err { background-color:#d2212f; }
+    .badge      { font-size:11px; font-weight:700;
+                  text-transform:uppercase; letter-spacing:0.12em; margin:0 0 6px; }
+    .badge.ok   { color:#bdc6f6; }
+    .badge.err  { color:#f5c2c6; }
+    .title      { font-size:24px; font-weight:700; color:#ffffff;
+                  line-height:1.25; margin:0; word-break:break-word; }
+    .body       { background-color:#f6f8f9; padding:28px 36px 24px; text-align:center; }
+    .body .icon { font-size:36px; line-height:1; margin:0 0 12px; }
+    .body p     { font-size:14px; color:#626a80; line-height:1.6; margin:0; }
+    .body .event-date  { font-size:14px; color:#626a80; line-height:1.4;
+                         margin:0 0 12px; }
+    .divider    { background-color:#e7e9eb; height:1px; padding:0;
+                  font-size:0; line-height:0; }
+    .footer     { background-color:#f6f8f9; padding:18px 36px; text-align:center; }
+    .footer p   { font-size:12px; color:#626a80; line-height:1.6; margin:0; }
   </style>
 </head>
 <body>
@@ -33,23 +36,28 @@
     <div class="card">
       {% if error %}
       <div class="header err">
-        <div class="icon">&#10060;</div>
-        <h1>{{ error_title }}</h1>
+        <p class="badge err">{{ error_title }}</p>
+        <p class="title">{{ error_title }}</p>
       </div>
       <div class="body">
-        <p class="message">{{ error }}</p>
+        <div class="icon">&#10060;</div>
+        <p>{{ error }}</p>
       </div>
       {% else %}
       <div class="header ok">
-        <div class="icon">{{ status_icon|safe }}</div>
-        <h1>{{ heading }}</h1>
+        <p class="badge ok">{{ heading }}</p>
+        <p class="title">{{ event_summary }}</p>
       </div>
       <div class="body">
-        {% if event_summary %}<div class="event-title">{{ event_summary }}</div>{% endif %}
+        {% if status_icon %}<div class="icon">{{ status_icon|safe }}</div>{% endif %}
         {% if event_date %}<div class="event-date">{{ event_date }}</div>{% endif %}
-        {% if message %}<p class="message">{{ message }}</p>{% endif %}
+        {% if message %}<p>{{ message }}</p>{% endif %}
       </div>
       {% endif %}
+      <div class="divider"></div>
+      <div class="footer">
+        <p>{{ app_name }}</p>
+      </div>
     </div>
   </div>
 </body>

--- a/src/backend/core/tests/test_rsvp.py
+++ b/src/backend/core/tests/test_rsvp.py
@@ -584,8 +584,8 @@ class TestRSVPEndToEndFlow(TestCase):
             alt[0] for alt in mail.outbox[0].alternatives if alt[1] == "text/html"
         )
 
-        # Find accept link by green button color (#16a34a)
-        accept_url = self._extract_rsvp_link(html_body, "#16a34a")
+        # Find accept link by blue button color (#435de6)
+        accept_url = self._extract_rsvp_link(html_body, "#435de6")
         token = self._extract_token_from_url(accept_url)
 
         # GET the confirm page
@@ -615,8 +615,8 @@ class TestRSVPEndToEndFlow(TestCase):
             alt[0] for alt in mail.outbox[0].alternatives if alt[1] == "text/html"
         )
 
-        # Find decline link by red button color (#dc2626)
-        decline_url = self._extract_rsvp_link(html_body, "#dc2626")
+        # Find decline link by red button color (#d2212f)
+        decline_url = self._extract_rsvp_link(html_body, "#d2212f")
         token = self._extract_token_from_url(decline_url)
 
         with patch.object(CalDAVHTTPClient, "internal_request") as mock_internal:
@@ -640,9 +640,9 @@ class TestRSVPEndToEndFlow(TestCase):
 
         # Each button has a distinct color
         colors = {
-            "accept": "#16a34a",  # green
-            "tentative": "#d97706",  # amber
-            "decline": "#dc2626",  # red
+            "accept": "#435de6",  # blue
+            "tentative": "#626a80",  # gray
+            "decline": "#d2212f",  # red
         }
         for label, color in colors.items():
             pattern = rf'<a\s+href="([^"]*)"[^>]*background-color:\s*{re.escape(color)}'
@@ -670,7 +670,7 @@ class TestRSVPEndToEndFlow(TestCase):
         html_body = next(
             alt[0] for alt in mail.outbox[0].alternatives if alt[1] == "text/html"
         )
-        accept_url = self._extract_rsvp_link(html_body, "#16a34a")
+        accept_url = self._extract_rsvp_link(html_body, "#435de6")
         token = self._extract_token_from_url(accept_url)
 
         mock_internal.return_value = _mock_resp(404, {"error": "Event not found"})

--- a/src/frontend/apps/calendars/src/features/i18n/translations.json
+++ b/src/frontend/apps/calendars/src/features/i18n/translations.json
@@ -416,6 +416,7 @@
         "invitation": {
           "title": "Event invitation",
           "heading": "Event invitation",
+          "badge": "Event invitation",
           "body": "{{organizer}} invites you to an event"
         },
         "update": {
@@ -433,6 +434,7 @@
         "reply": {
           "title": "Event reply",
           "heading": "Reply received",
+          "badge": "Response",
           "body": "{{attendee}} has replied to your event"
         },
         "labels": {
@@ -1336,6 +1338,7 @@
         "invitation": {
           "title": "Invitation à un événement",
           "heading": "Invitation à un événement",
+          "badge": "Invitation à un événement",
           "body": "{{organizer}} vous invite à un événement"
         },
         "update": {
@@ -1353,6 +1356,7 @@
         "reply": {
           "title": "Réponse à l'événement",
           "heading": "Réponse reçue",
+          "badge": "Réponse",
           "body": "{{attendee}} a répondu à votre événement"
         },
         "labels": {
@@ -1998,6 +2002,7 @@
         "invitation": {
           "title": "Uitnodiging voor evenement",
           "heading": "Uitnodiging voor evenement",
+          "badge": "Uitnodiging voor evenement",
           "body": "{{organizer}} nodigt u uit voor een evenement"
         },
         "update": {
@@ -2015,6 +2020,7 @@
         "reply": {
           "title": "Antwoord op evenement",
           "heading": "Antwoord ontvangen",
+          "badge": "Antwoord",
           "body": "{{attendee}} heeft gereageerd op uw evenement"
         },
         "labels": {


### PR DESCRIPTION
## Summary

Restyles the calendar invitation / update / cancel / reply emails and the
`/rsvp` confirm + response pages into a consistent card layout: a colored
header strip with an uppercase action badge + title, body, divider, and
footer. Driven by a small new `emails/_invitation_layout.html` Django base
template that the four email templates extend via `{% extends %}`.

The same card design is reused on the `/rsvp` pages, with the event title
as the card title and `{{ app_name }}` in the footer, so the user clearly
sees *what* event they RSVP'd for.

## What changes

- **New base**: `src/backend/core/templates/emails/_invitation_layout.html`
  — table-based, inline styles, email-client-safe. Blocks: `header_color`,
  `badge_color`, `body`.
- **Email templates** restyled (all reuse existing context vars — no service
  changes required):
  - `calendar_invitation.html` — default blue, RSVP buttons.
  - `calendar_invitation_update.html` — default blue, RSVP buttons.
  - `calendar_invitation_cancel.html` — red header, strike-through date.
  - `calendar_invitation_reply.html` — green header.
- **`/rsvp` pages** restyled with the same card design:
  - `templates/rsvp/confirm.html` — auto-submit page, blue card + footer.
  - `templates/rsvp/response.html` — success: blue card with event summary
    as the title; error: red header.
  - `viewsets_rsvp.py` — pass `app_name = settings.APP_NAME` to the three
    render contexts so the footer reads "via {{ app_name }}".

## Translations

- Added `email.invitation.badge` (en / fr / nl) — the layout's uppercase
  header label. Previously absent (only `update` / `cancel` had `badge`),
  which would have surfaced the raw key.
- Added `email.reply.badge` (en / fr / nl) — same reason.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar invitation/update/cancel/reply emails now use a shared, overridable HTML layout for consistent appearance and configurable colors/badge/text blocks
  * Added badge translations for invitation and reply in English, French, and Dutch

* **Style**
  * RSVP confirmation and response pages redesigned with a compact wrap/card layout and shared RSVP styles

* **Tests**
  * RSVP tests updated to expect the new RSVP button colors and selectors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->