### PR TITLE
🐛(frontend) fix feedback widget mode

### DIFF
--- a/src/frontend/src/features/feedback/Feedback.tsx
+++ b/src/frontend/src/features/feedback/Feedback.tsx
@@ -57,14 +57,14 @@ export const Feedback = (props: { buttonProps?: Partial<ButtonProps> }) => {
   };
 
   const onClick = () => {
-    if (config?.FRONTEND_FEEDBACK_BUTTON_IDLE) {
+    if (!config?.FRONTEND_FEEDBACK_BUTTON_IDLE) {
+      modal.open();
       return;
     }
     if (config?.FRONTEND_FEEDBACK_MESSAGES_WIDGET_ENABLED) {
       showWidget();
       return;
     }
-    modal.open();
   };
 
   if (!showFeedbackButton()) {


### PR DESCRIPTION
## Purpose

To display the Messages widget, the feedback button must be in idle mode but currently in this one, the onClick event is a noop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the interaction between the feedback modal and messages widget by adjusting their display sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->