### PR TITLE
🔧(compose) use 1000 as gid for all platforms for frontend-dev service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BLUE := \033[1;34m
 DOCKER_UID          = $(shell id -u)
 DOCKER_GID          = $(shell id -g)
 DOCKER_USER         = $(DOCKER_UID):$(DOCKER_GID)
-COMPOSE             = DOCKER_USER=$(DOCKER_USER) docker compose
+COMPOSE             = DOCKER_USER=$(DOCKER_USER) DOCKER_UID=$(DOCKER_UID) docker compose
 COMPOSE_EXEC        = $(COMPOSE) exec
 COMPOSE_EXEC_APP    = $(COMPOSE_EXEC) backend-dev
 COMPOSE_RUN         = $(COMPOSE) run --rm

--- a/compose.yaml
+++ b/compose.yaml
@@ -131,7 +131,11 @@ services:
       - /app/.venv
 
   frontend-dev:
-    user: "${DOCKER_USER:-1000}"
+    # Keep the host UID (file ownership on the bind-mounted sources) but force
+    # the GID to 1000, the `node` group that owns the image's group-writable
+    # node_modules. On macOS the host GID is 20 (staff), not 1000, so the
+    # default ${DOCKER_USER} would leave Vite unable to write node_modules/.vite
+    user: "${DOCKER_UID:-1000}:1000"
     build:
       context: src/frontend
       target: calendars-dev


### PR DESCRIPTION
## Purpose

On Mac OS gid is 20 and on linux it is 1000. The frontend Dockerfile set node user and group as owner of project resources. But the frontend-dev service use the local user when the service is running. This scenario prevents vite to write within node_modules folder so the frontend application is broken. In order to make the service platform agnostic, we always use 1000 as gid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container file permissions for the frontend development environment, helping prevent write issues with generated files and dependencies.
  * Updated the development setup to better handle different host user/group configurations, making local container workflows more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->