### PR TITLE
✨(frontend) add monthly "nth weekday" recurrence option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to
 
 ### Added
 
-- ✨(frontend) add monthly "nth weekday" recurrence option
+- ✨(frontend) add monthly "nth weekday" recurrence option #70
 
 ## [0.1.0] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(frontend) add monthly "nth weekday" recurrence option
+
 ## [0.1.0] - 2026-06-18
 
 First public release.

--- a/src/frontend/src/features/calendar/components/scheduler/RecurrenceEditor.scss
+++ b/src/frontend/src/features/calendar/components/scheduler/RecurrenceEditor.scss
@@ -124,4 +124,35 @@
     align-items: center;
     gap: 0.5rem;
   }
+
+  &__monthly-mode-options {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  &__monthly-mode-btn {
+    border: 1px solid var(--c--theme--colors--greyscale-300, #d1d5db);
+    border-radius: 20px;
+    padding: 0.375rem 0.75rem;
+    background: transparent;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: all 0.15s;
+    color: inherit;
+
+    &:hover {
+      border-color: var(--c--theme--colors--greyscale-400, #9ca3af);
+    }
+
+    &--active {
+      border-color: var(--c--theme--colors--primary-600, #1a73e8);
+      color: var(--c--theme--colors--primary-600, #1a73e8);
+      background: var(--c--theme--colors--primary-50, #eff6ff);
+
+      &:hover {
+        border-color: var(--c--theme--colors--primary-700, #1557b0);
+        color: var(--c--theme--colors--primary-700, #1557b0);
+      }
+    }
+  }
 }

--- a/src/frontend/src/features/calendar/components/scheduler/RecurrenceEditor.tsx
+++ b/src/frontend/src/features/calendar/components/scheduler/RecurrenceEditor.tsx
@@ -39,9 +39,45 @@ const MONTHS = [
   { value: 12, key: "december" },
 ];
 
+const ORDINALS = [
+  { value: 1, key: "first" },
+  { value: 2, key: "second" },
+  { value: 3, key: "third" },
+  { value: 4, key: "fourth" },
+  { value: -1, key: "last" },
+];
+
+const WEEKDAYS_FULL = [
+  { value: "MO", key: "monday" },
+  { value: "TU", key: "tuesday" },
+  { value: "WE", key: "wednesday" },
+  { value: "TH", key: "thursday" },
+  { value: "FR", key: "friday" },
+  { value: "SA", key: "saturday" },
+  { value: "SU", key: "sunday" },
+] as const;
+
+type MonthlyMode = "dayOfMonth" | "nthWeekday";
+
+export function getMonthlyMode(value?: IcsRecurrenceRule): MonthlyMode {
+  return value?.byDay?.length ? "nthWeekday" : "dayOfMonth";
+}
+
+export function getMonthlyWeekday(value?: IcsRecurrenceRule): IcsWeekDay {
+  const entry = value?.byDay?.[0];
+  if (!entry) return "MO";
+  return typeof entry === "string" ? entry : entry.day;
+}
+
+export function getMonthlyOccurrence(value?: IcsRecurrenceRule): number {
+  const entry = value?.byDay?.[0];
+  if (!entry || typeof entry === "string") return 1;
+  return entry.occurrence ?? 1;
+}
+
 const ADVANCED_RRULE_KEYS: (keyof IcsRecurrenceRule)[] = ["bySetPos", "byYearday", "byWeekNo"];
 
-function hasAdvancedProperties(rule?: IcsRecurrenceRule): boolean {
+export function hasAdvancedProperties(rule?: IcsRecurrenceRule): boolean {
   if (!rule) return false;
   return ADVANCED_RRULE_KEYS.some((key) => rule[key] !== undefined && rule[key] !== null);
 }
@@ -188,6 +224,38 @@ export function RecurrenceEditor({ value, onChange }: RecurrenceEditorProps) {
     [t],
   );
 
+  const ordinalOptions = useMemo(
+    () =>
+      ORDINALS.map((ordinal) => ({
+        value: String(ordinal.value),
+        label: t(`calendar.recurrence.ordinals.${ordinal.key}`),
+      })),
+    [t],
+  );
+
+  const weekdayFullOptions = useMemo(
+    () =>
+      WEEKDAYS_FULL.map((day) => ({
+        value: day.value,
+        label: t(`calendar.weekdaysFull.${day.key}`),
+      })),
+    [t],
+  );
+
+  const monthlyModeOptions = useMemo(
+    () => [
+      {
+        value: "dayOfMonth" as MonthlyMode,
+        label: t("calendar.recurrence.monthlyMode.dayOfMonth"),
+      },
+      {
+        value: "nthWeekday" as MonthlyMode,
+        label: t("calendar.recurrence.monthlyMode.nthWeekday"),
+      },
+    ],
+    [t],
+  );
+
   const summary = useMemo((): string => {
     if (!isCustom || !value) return "";
 
@@ -205,6 +273,16 @@ export function RecurrenceEditor({ value, onChange }: RecurrenceEditorProps) {
         return t(`calendar.recurrence.weekdays.${dayKey.toLowerCase()}`);
       });
       result += ` · ${dayLabels.join(", ")}`;
+    }
+
+    if (freq === "MONTHLY" && value.byDay?.length) {
+      const occurrence = getMonthlyOccurrence(value);
+      const weekday = getMonthlyWeekday(value);
+      const ordinalMeta = ORDINALS.find((o) => o.value === occurrence);
+      const weekdayMeta = WEEKDAYS_FULL.find((w) => w.value === weekday);
+      const ordinalLabel = ordinalMeta ? t(`calendar.recurrence.ordinals.${ordinalMeta.key}`) : "";
+      const weekdayLabel = weekdayMeta ? t(`calendar.weekdaysFull.${weekdayMeta.key}`) : "";
+      result += ` · ${ordinalLabel} ${weekdayLabel}`;
     }
 
     // Defer to ``getEndType``: a ``count`` / ``until`` past the
@@ -300,7 +378,31 @@ export function RecurrenceEditor({ value, onChange }: RecurrenceEditorProps) {
     handleChange({ byMonth: [month] });
   };
 
+  const handleMonthlyModeChange = (mode: MonthlyMode) => {
+    if (mode === "dayOfMonth") {
+      handleChange({ byDay: undefined, byMonthday: [getMonthDay()] });
+      return;
+    }
+
+    const today = new Date();
+    const defaultWeekday = WEEKDAY_KEYS[(today.getDay() + 6) % 7];
+    const defaultOccurrence = Math.min(4, Math.ceil(today.getDate() / 7));
+    handleChange({
+      byMonthday: undefined,
+      byDay: [{ day: defaultWeekday, occurrence: defaultOccurrence }],
+    });
+  };
+
+  const handleMonthlyWeekdayChange = (day: IcsWeekDay) => {
+    handleChange({ byDay: [{ day, occurrence: getMonthlyOccurrence(value) }] });
+  };
+
+  const handleMonthlyOccurrenceChange = (occurrence: number) => {
+    handleChange({ byDay: [{ day: getMonthlyWeekday(value), occurrence }] });
+  };
+
   const endType = getEndType(value);
+  const monthlyMode = getMonthlyMode(value);
 
   const monthDay = getMonthDay();
   const dateWarning =
@@ -382,26 +484,62 @@ export function RecurrenceEditor({ value, onChange }: RecurrenceEditorProps) {
 
           {value?.frequency === "MONTHLY" && (
             <div className="recurrence-editor__day-select">
-              <span className="recurrence-editor__label">
-                {t("calendar.recurrence.repeatOnDay")}
-              </span>
-              <div className="recurrence-editor__interval">
-                <span>{t("calendar.recurrence.dayOfMonth")}</span>
-                <Input
-                  label=""
-                  type="number"
-                  min={1}
-                  max={31}
-                  variant="classic"
-                  value={getMonthDay()}
-                  onChange={(e) => {
-                    const day = parseInt(e.target.value) || 1;
-                    if (day >= 1 && day <= 31) {
-                      handleMonthDayChange(day);
-                    }
-                  }}
-                />
+              <div className="recurrence-editor__monthly-mode-options">
+                {monthlyModeOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={`recurrence-editor__monthly-mode-btn ${monthlyMode === option.value ? "recurrence-editor__monthly-mode-btn--active" : ""}`}
+                    onClick={() => handleMonthlyModeChange(option.value)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
               </div>
+
+              {monthlyMode === "dayOfMonth" && (
+                <div className="recurrence-editor__interval">
+                  <span>{t("calendar.recurrence.dayOfMonth")}</span>
+                  <Input
+                    label=""
+                    type="number"
+                    min={1}
+                    max={31}
+                    variant="classic"
+                    value={getMonthDay()}
+                    onChange={(e) => {
+                      const day = parseInt(e.target.value) || 1;
+                      if (day >= 1 && day <= 31) {
+                        handleMonthDayChange(day);
+                      }
+                    }}
+                  />
+                </div>
+              )}
+
+              {monthlyMode === "nthWeekday" && (
+                <div className="recurrence-editor__interval">
+                  <span>{t("calendar.recurrence.repeatOnWeekday")}</span>
+                  <Select
+                    label=""
+                    variant="classic"
+                    value={String(getMonthlyOccurrence(value))}
+                    options={ordinalOptions}
+                    onChange={(e) =>
+                      handleMonthlyOccurrenceChange(parseInt(String(e.target.value)) || 1)
+                    }
+                  />
+                  <Select
+                    label=""
+                    variant="classic"
+                    value={getMonthlyWeekday(value)}
+                    options={weekdayFullOptions}
+                    onChange={(e) =>
+                      handleMonthlyWeekdayChange(String(e.target.value ?? "MO") as IcsWeekDay)
+                    }
+                  />
+                </div>
+              )}
             </div>
           )}
 

--- a/src/frontend/src/features/calendar/components/scheduler/__tests__/RecurrenceEditor.helpers.test.ts
+++ b/src/frontend/src/features/calendar/components/scheduler/__tests__/RecurrenceEditor.helpers.test.ts
@@ -1,6 +1,14 @@
 import type { IcsRecurrenceRule } from "ts-ics";
 
-import { getEndType, isForeverCount, isForeverUntil } from "../RecurrenceEditor";
+import {
+  getEndType,
+  getMonthlyMode,
+  getMonthlyOccurrence,
+  getMonthlyWeekday,
+  hasAdvancedProperties,
+  isForeverCount,
+  isForeverUntil,
+} from "../RecurrenceEditor";
 
 function rule(overrides: Partial<IcsRecurrenceRule>): IcsRecurrenceRule {
   return {
@@ -97,5 +105,68 @@ describe("RecurrenceEditor end-type classification", () => {
     it("returns 'never' for far-future UNTIL", () => {
       expect(getEndType(rule({ frequency: "DAILY", until: dateIn(25) }))).toBe("never");
     });
+  });
+});
+
+describe("RecurrenceEditor monthly nth-weekday helpers", () => {
+  describe("getMonthlyMode", () => {
+    it("returns 'dayOfMonth' for undefined rules", () => {
+      expect(getMonthlyMode(undefined)).toBe("dayOfMonth");
+    });
+
+    it("returns 'dayOfMonth' for a rule using byMonthday", () => {
+      expect(getMonthlyMode(rule({ frequency: "MONTHLY", byMonthday: [15] }))).toBe("dayOfMonth");
+    });
+
+    it("returns 'nthWeekday' for a rule using byDay with an occurrence", () => {
+      expect(
+        getMonthlyMode(rule({ frequency: "MONTHLY", byDay: [{ day: "TU", occurrence: 1 }] })),
+      ).toBe("nthWeekday");
+    });
+  });
+
+  describe("getMonthlyWeekday", () => {
+    it("returns 'MO' fallback when byDay is absent", () => {
+      expect(getMonthlyWeekday(rule({ frequency: "MONTHLY", byMonthday: [15] }))).toBe("MO");
+    });
+
+    it("returns the day from byDay[0]", () => {
+      expect(
+        getMonthlyWeekday(rule({ frequency: "MONTHLY", byDay: [{ day: "FR", occurrence: 2 }] })),
+      ).toBe("FR");
+    });
+  });
+
+  describe("getMonthlyOccurrence", () => {
+    it("returns 1 fallback when byDay is absent", () => {
+      expect(getMonthlyOccurrence(rule({ frequency: "MONTHLY", byMonthday: [15] }))).toBe(1);
+    });
+
+    it("returns the occurrence from byDay[0]", () => {
+      expect(
+        getMonthlyOccurrence(rule({ frequency: "MONTHLY", byDay: [{ day: "TU", occurrence: 3 }] })),
+      ).toBe(3);
+    });
+
+    it("correctly returns a negative occurrence (last weekday of month)", () => {
+      expect(
+        getMonthlyOccurrence(
+          rule({ frequency: "MONTHLY", byDay: [{ day: "FR", occurrence: -1 }] }),
+        ),
+      ).toBe(-1);
+    });
+  });
+
+  it("agrees across getters for a 'last Friday of the month' rule", () => {
+    const lastFriday = rule({ frequency: "MONTHLY", byDay: [{ day: "FR", occurrence: -1 }] });
+    expect(getMonthlyMode(lastFriday)).toBe("nthWeekday");
+    expect(getMonthlyWeekday(lastFriday)).toBe("FR");
+    expect(getMonthlyOccurrence(lastFriday)).toBe(-1);
+  });
+
+  it("does not treat a monthly nth-weekday byDay as an advanced property", () => {
+    expect(
+      hasAdvancedProperties(rule({ frequency: "MONTHLY", byDay: [{ day: "FR", occurrence: -1 }] })),
+    ).toBe(false);
   });
 });

--- a/src/frontend/src/features/i18n/translations.json
+++ b/src/frontend/src/features/i18n/translations.json
@@ -317,7 +317,12 @@
           "repeatOn": "Repeat on",
           "repeatOnDay": "Repeat on day",
           "repeatOnDate": "Repeat on date",
+          "repeatOnWeekday": "Repeat on the",
           "dayOfMonth": "Day",
+          "monthlyMode": {
+            "dayOfMonth": "Day of the month",
+            "nthWeekday": "Day of the week"
+          },
           "endsLabel": "Ends",
           "never": "Never",
           "on": "On",
@@ -345,6 +350,13 @@
             "october": "October",
             "november": "November",
             "december": "December"
+          },
+          "ordinals": {
+            "first": "First",
+            "second": "Second",
+            "third": "Third",
+            "fourth": "Fourth",
+            "last": "Last"
           },
           "warnings": {
             "februaryMax": "February has at most 29 days",
@@ -1270,7 +1282,12 @@
           "repeatOn": "Répéter le",
           "repeatOnDay": "Répéter le jour",
           "repeatOnDate": "Répéter à la date",
+          "repeatOnWeekday": "Répéter le",
           "dayOfMonth": "Jour",
+          "monthlyMode": {
+            "dayOfMonth": "Jour du mois",
+            "nthWeekday": "Jour de la semaine"
+          },
           "endsLabel": "Se termine",
           "never": "Jamais",
           "on": "Le",
@@ -1298,6 +1315,13 @@
             "october": "Octobre",
             "november": "Novembre",
             "december": "Décembre"
+          },
+          "ordinals": {
+            "first": "1er",
+            "second": "2e",
+            "third": "3e",
+            "fourth": "4e",
+            "last": "Dernier"
           },
           "warnings": {
             "februaryMax": "Février a au maximum 29 jours",
@@ -1965,7 +1989,12 @@
           "repeatOn": "Herhaal op",
           "repeatOnDay": "Herhaal op dag",
           "repeatOnDate": "Herhaal op datum",
+          "repeatOnWeekday": "Herhaal op de",
           "dayOfMonth": "Dag",
+          "monthlyMode": {
+            "dayOfMonth": "Dag van de maand",
+            "nthWeekday": "Dag van de week"
+          },
           "endsLabel": "Eindigt",
           "never": "Nooit",
           "on": "Op",
@@ -1993,6 +2022,13 @@
             "october": "Oktober",
             "november": "November",
             "december": "December"
+          },
+          "ordinals": {
+            "first": "Eerste",
+            "second": "Tweede",
+            "third": "Derde",
+            "fourth": "Vierde",
+            "last": "Laatste"
           },
           "warnings": {
             "februaryMax": "Februari heeft maximaal 29 dagen",


### PR DESCRIPTION
## Purpose

Users could not create an event recurring on e.g. "the 1st Tuesday of
every month" — the monthly recurrence editor only supported "on day N
of the month" (`BYMONTHDAY`), with no way to express an ordinal
weekday (`BYDAY=1TU`).

## Proposal

- Add a "day of the week" sub-mode to the monthly recurrence editor,
  alongside the existing "day of month" option, with ordinal (1st /
  2nd / 3rd / 4th / last) + weekday selects.
- `ts-ics` already serializes `byDay: [{ day, occurrence }]` correctly
  to RRULE (`BYDAY=1TU`, `BYDAY=-1FR`, ...), so no backend or CalDAV
  changes were needed.
- Added unit tests for the new helpers and translations (en/fr/nl).

- [x] `make test-front`
- [x] `make typecheck-front`
- [x] `make lint-front`