### PR TITLE
🐛(global) fix mailbox-owned calendar deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(global) fix mailbox-owned calendars that could be created without
+  limit but never truly deleted (#73)
+
 ## [0.1.0] - 2026-06-18
 
 First public release.

--- a/src/backend/core/api/viewsets_setup.py
+++ b/src/backend/core/api/viewsets_setup.py
@@ -91,3 +91,41 @@ class SetupView(APIView):
                 {"error": "Failed to create calendar"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
+
+    def delete(self, request):
+        """Delete a mailbox-owned calendar, for every mailbox user.
+
+        Body: {"mailbox_email": "contact@company.com", "calendar_uri": "..."}
+        """
+        mailbox_email = request.data.get("mailbox_email")
+        calendar_uri = request.data.get("calendar_uri")
+        if not mailbox_email or not calendar_uri:
+            return Response(
+                {"error": "mailbox_email and calendar_uri are required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            SetupService().delete_mailbox_calendar(
+                request.user, mailbox_email, calendar_uri
+            )
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except SetupServiceError as exc:
+            logger.warning(
+                "Mailbox calendar delete rejected for user %s (mailbox=%s): %s",
+                request.user.pk,
+                mailbox_email,
+                exc,
+            )
+            return Response(
+                {"error": str(exc)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception(
+                "Failed to delete mailbox calendar for %s", request.user.pk
+            )
+            return Response(
+                {"error": "Failed to delete calendar"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )

--- a/src/backend/core/services/setup_service.py
+++ b/src/backend/core/services/setup_service.py
@@ -158,26 +158,9 @@ class SetupService:
         only — it is never stored on the (invisible) owner row and never
         propagated to other mailbox users via the share fan-out.
         """
-        if not settings.FEATURE_MESSAGES_INTEGRATION:
-            raise SetupServiceError("Messages integration is not enabled")
-
-        # Verify user has sender/admin access
-        mailboxes = self.messages.get_user_mailboxes(user.email)
-        user_mailbox = next(
-            (mb for mb in mailboxes if mb.get("email") == mailbox_email),
-            None,
+        user_mailbox = self._require_mailbox_send_role(
+            user, mailbox_email, action="create a mailbox calendar"
         )
-        if not user_mailbox:
-            raise SetupServiceError(
-                f"User {user.email} does not have access to mailbox {mailbox_email}"
-            )
-
-        user_role = user_mailbox.get("role", "viewer")
-        if user_role not in SEND_ROLES:
-            raise SetupServiceError(
-                f"User needs 'sender' or 'admin' role to create a mailbox calendar"
-                f" (current role: {user_role})"
-            )
 
         # Resolve org from the mailbox's mail domain custom attributes
         org_id = _resolve_mailbox_org_id(user_mailbox)
@@ -209,6 +192,51 @@ class SetupService:
             "mailbox_email": mailbox_email,
             "principal_uri": f"principals/mailboxes/{mailbox_email}",
         }
+
+    def delete_mailbox_calendar(self, user, mailbox_email, calendar_uri):
+        """Delete a calendar owned by a mailbox principal, for everyone.
+
+        Requires the caller to hold sender/admin role on the mailbox
+        (same gate as creation). Unlike a plain CalDAV DELETE — which
+        only ever removes the caller's own share — this reaches the
+        real owner-branch delete via the internal API, so the
+        calendar disappears for every mailbox user, not just the
+        caller.
+
+        Args:
+            user: The OIDC user requesting deletion.
+            mailbox_email: The mailbox the calendar is owned by.
+            calendar_uri: The calendar's URI under the CALLER's own
+                principal (the last segment of its CalDAV path), as
+                exposed to the frontend.
+
+        Raises:
+            SetupServiceError on failure.
+        """
+        self._require_mailbox_send_role(
+            user, mailbox_email, action="delete a mailbox calendar"
+        )
+
+        try:
+            resp = self._http.internal_request(
+                "DELETE",
+                user,
+                f"internal-api/calendars/{calendar_uri}",
+                json={"mailbox_email": mailbox_email},
+            )
+        except Exception as exc:
+            raise SetupServiceError(f"Failed to delete calendar: {exc}") from exc
+
+        if resp.status_code == 404:
+            raise SetupServiceError(f"Calendar '{calendar_uri}' not found")
+        if resp.status_code in (400, 403):
+            try:
+                error_msg = resp.json().get("error", "")
+            except ValueError:
+                error_msg = ""
+            raise SetupServiceError(error_msg or "Cannot delete this calendar")
+        if resp.status_code != 200:
+            raise SetupServiceError(f"Failed to delete calendar: {resp.status_code}")
 
     # ------------------------------------------------------------------
     # Sync: GET /api/v1.0/mailboxes/
@@ -320,6 +348,36 @@ class SetupService:
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _require_mailbox_send_role(self, user, mailbox_email, action):
+        """Verify the user has sender/admin role on a mailbox, or raise.
+
+        Shared gate for any mailbox operation that should only be
+        available to users who can send as that mailbox (currently:
+        creating and deleting a mailbox-owned calendar).
+
+        Returns the matching Messages mailbox dict on success.
+        """
+        if not settings.FEATURE_MESSAGES_INTEGRATION:
+            raise SetupServiceError("Messages integration is not enabled")
+
+        mailboxes = self.messages.get_user_mailboxes(user.email)
+        user_mailbox = next(
+            (mb for mb in mailboxes if mb.get("email") == mailbox_email),
+            None,
+        )
+        if not user_mailbox:
+            raise SetupServiceError(
+                f"User {user.email} does not have access to mailbox {mailbox_email}"
+            )
+
+        user_role = user_mailbox.get("role", "viewer")
+        if user_role not in SEND_ROLES:
+            raise SetupServiceError(
+                f"User needs 'sender' or 'admin' role to {action}"
+                f" (current role: {user_role})"
+            )
+        return user_mailbox
 
     def _create_calendar(  # noqa: PLR0913  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,

--- a/src/backend/core/tests/test_setup_mailbox_calendar_delete.py
+++ b/src/backend/core/tests/test_setup_mailbox_calendar_delete.py
@@ -1,0 +1,234 @@
+"""Tests for deleting a MAILBOX-owned calendar (issue #72).
+
+Unlike a plain CalDAV DELETE — which only ever removes the caller's
+own share of a mailbox calendar — ``DELETE /api/v1.0/setup/`` reaches
+the real owner-branch delete via the internal API, so the calendar
+disappears for every mailbox user.
+"""
+
+from unittest import mock
+
+from django.test import override_settings
+
+import pytest
+from rest_framework.status import (
+    HTTP_204_NO_CONTENT,
+    HTTP_400_BAD_REQUEST,
+    HTTP_401_UNAUTHORIZED,
+)
+from rest_framework.test import APIClient
+
+from core import factories
+from core.entitlements.factory import get_entitlements_backend
+
+_SETTINGS = {
+    "ENTITLEMENTS_BACKEND": "core.entitlements.backends.local.LocalEntitlementsBackend",
+    "ENTITLEMENTS_BACKEND_PARAMETERS": {},
+    "CALDAV_INTERNAL_API_KEY": "test-internal-key",
+    "FEATURE_MESSAGES_INTEGRATION": True,
+    "MESSAGES_API_URL": "http://messages.example",
+    "MESSAGES_API_KEY": "test-messages-key",
+}
+
+
+def _authed_client():
+    org = factories.OrganizationFactory(external_id="test-org")
+    user = factories.UserFactory(organization=org)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client, user
+
+
+@pytest.mark.django_db
+@override_settings(**_SETTINGS)
+def test_delete_mailbox_calendar_requires_auth():
+    """DELETE /setup/ requires authentication."""
+    get_entitlements_backend.cache_clear()
+    client = APIClient()
+    response = client.delete(
+        "/api/v1.0/setup/",
+        {"mailbox_email": "contact@co.example", "calendar_uri": "default"},
+        format="json",
+    )
+    assert response.status_code == HTTP_401_UNAUTHORIZED
+    get_entitlements_backend.cache_clear()
+
+
+@pytest.mark.django_db
+@override_settings(**_SETTINGS)
+def test_delete_mailbox_calendar_missing_params():
+    """Both mailbox_email and calendar_uri are required."""
+    get_entitlements_backend.cache_clear()
+    client, _user = _authed_client()
+
+    response = client.delete("/api/v1.0/setup/", {}, format="json")
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    get_entitlements_backend.cache_clear()
+
+
+@pytest.mark.django_db
+@override_settings(**_SETTINGS)
+def test_delete_mailbox_calendar_requires_send_role():
+    """A viewer-role user cannot delete the mailbox's calendar."""
+    get_entitlements_backend.cache_clear()
+    client, _user = _authed_client()
+
+    with (
+        mock.patch("core.services.setup_service.MessagesService") as mock_messages_cls,
+        mock.patch(
+            "core.services.caldav_service.requests.Session.request"
+        ) as mock_request,
+    ):
+        mock_messages_cls.return_value.get_user_mailboxes.return_value = [
+            {"email": "contact@co.example", "role": "viewer", "users": []}
+        ]
+
+        response = client.delete(
+            "/api/v1.0/setup/",
+            {"mailbox_email": "contact@co.example", "calendar_uri": "default"},
+            format="json",
+        )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert "sender" in response.json()["error"]
+    mock_request.assert_not_called()
+    get_entitlements_backend.cache_clear()
+
+
+@pytest.mark.django_db
+@override_settings(**_SETTINGS)
+def test_delete_mailbox_calendar_no_access_to_mailbox():
+    """A user with no role at all on the mailbox is rejected."""
+    get_entitlements_backend.cache_clear()
+    client, _user = _authed_client()
+
+    with (
+        mock.patch("core.services.setup_service.MessagesService") as mock_messages_cls,
+        mock.patch(
+            "core.services.caldav_service.requests.Session.request"
+        ) as mock_request,
+    ):
+        mock_messages_cls.return_value.get_user_mailboxes.return_value = []
+
+        response = client.delete(
+            "/api/v1.0/setup/",
+            {"mailbox_email": "contact@co.example", "calendar_uri": "default"},
+            format="json",
+        )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    mock_request.assert_not_called()
+    get_entitlements_backend.cache_clear()
+
+
+@pytest.mark.django_db
+@override_settings(**_SETTINGS)
+def test_delete_mailbox_calendar_success():
+    """A sender-role user can delete the mailbox's calendar for everyone."""
+    get_entitlements_backend.cache_clear()
+    client, _user = _authed_client()
+
+    with (
+        mock.patch("core.services.setup_service.MessagesService") as mock_messages_cls,
+        mock.patch(
+            "core.services.caldav_service.requests.Session.request"
+        ) as mock_request,
+    ):
+        mock_messages_cls.return_value.get_user_mailboxes.return_value = [
+            {"email": "contact@co.example", "role": "admin", "users": []}
+        ]
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"deleted": True}
+        mock_response.text = '{"deleted": true}'
+        mock_request.return_value = mock_response
+
+        response = client.delete(
+            "/api/v1.0/setup/",
+            {"mailbox_email": "contact@co.example", "calendar_uri": "some-uuid"},
+            format="json",
+        )
+
+    assert response.status_code == HTTP_204_NO_CONTENT
+
+    mock_request.assert_called_once()
+    call_kwargs = mock_request.call_args
+    url = call_kwargs.kwargs.get("url", "") or (
+        call_kwargs.args[1] if len(call_kwargs.args) > 1 else ""
+    )
+    assert "internal-api/calendars/some-uuid" in url
+    method = call_kwargs.kwargs.get("method") or (
+        call_kwargs.args[0] if call_kwargs.args else ""
+    )
+    assert method == "DELETE"
+    get_entitlements_backend.cache_clear()
+
+
+@pytest.mark.django_db
+@override_settings(**_SETTINGS)
+def test_delete_mailbox_calendar_not_found():
+    """A 404 from the internal API surfaces as a rejected request, not a 500."""
+    get_entitlements_backend.cache_clear()
+    client, _user = _authed_client()
+
+    with (
+        mock.patch("core.services.setup_service.MessagesService") as mock_messages_cls,
+        mock.patch(
+            "core.services.caldav_service.requests.Session.request"
+        ) as mock_request,
+    ):
+        mock_messages_cls.return_value.get_user_mailboxes.return_value = [
+            {"email": "contact@co.example", "role": "admin", "users": []}
+        ]
+        mock_response = mock.Mock()
+        mock_response.status_code = 404
+        mock_response.text = '{"error": "Calendar not found"}'
+        mock_request.return_value = mock_response
+
+        response = client.delete(
+            "/api/v1.0/setup/",
+            {"mailbox_email": "contact@co.example", "calendar_uri": "missing"},
+            format="json",
+        )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert "not found" in response.json()["error"]
+    get_entitlements_backend.cache_clear()
+
+
+@pytest.mark.django_db
+@override_settings(**_SETTINGS)
+def test_delete_mailbox_calendar_ownership_mismatch():
+    """A 403 (calendar belongs to a different mailbox) is surfaced, not a 500."""
+    get_entitlements_backend.cache_clear()
+    client, _user = _authed_client()
+
+    with (
+        mock.patch("core.services.setup_service.MessagesService") as mock_messages_cls,
+        mock.patch(
+            "core.services.caldav_service.requests.Session.request"
+        ) as mock_request,
+    ):
+        mock_messages_cls.return_value.get_user_mailboxes.return_value = [
+            {"email": "contact@co.example", "role": "admin", "users": []}
+        ]
+        mock_response = mock.Mock()
+        mock_response.status_code = 403
+        mock_response.json.return_value = {
+            "error": "Calendar does not belong to the given mailbox"
+        }
+        mock_response.text = (
+            '{"error": "Calendar does not belong to the given mailbox"}'
+        )
+        mock_request.return_value = mock_response
+
+        response = client.delete(
+            "/api/v1.0/setup/",
+            {"mailbox_email": "contact@co.example", "calendar_uri": "someone-elses"},
+            format="json",
+        )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert "does not belong" in response.json()["error"]
+    get_entitlements_backend.cache_clear()

--- a/src/caldav/src/InternalApiPlugin.php
+++ b/src/caldav/src/InternalApiPlugin.php
@@ -10,6 +10,7 @@
  *   DELETE /internal-api/resources/{resource_id}  Delete a resource principal
  *   POST   /internal-api/import/{user}/{calendar} Bulk import ICS events
  *   POST   /internal-api/calendars/               Create a calendar (and principal if needed)
+ *   DELETE /internal-api/calendars/{calendar_uri} Delete a MAILBOX-owned calendar for everyone
  *   POST   /internal-api/sync-mailbox-acls/     Sync Messages ACL shares for one user
  *   POST   /internal-api/rsvp/                  Update attendee PARTSTAT by event UID
  *
@@ -124,6 +125,12 @@ class InternalApiPlugin extends ServerPlugin
         // Route: POST /internal-api/calendars/
         if ($method === 'POST' && preg_match('#^internal-api/calendars/?$#', $path)) {
             $this->handleCreateCalendar($request, $response);
+            return false;
+        }
+
+        // Route: DELETE /internal-api/calendars/{calendar_uri}
+        if ($method === 'DELETE' && preg_match('#^internal-api/calendars/([^/]+)$#', $path, $matches)) {
+            $this->handleDeleteMailboxCalendar($request, $response, $matches[1]);
             return false;
         }
 
@@ -781,6 +788,123 @@ class InternalApiPlugin extends ServerPlugin
             'caller_calendar_uri' => $callerCalendarUri,
             'created' => true,
         ]));
+        return false;
+    }
+
+    /**
+     * DELETE /internal-api/calendars/{calendar_uri}
+     * Delete a MAILBOX-owned calendar for every mailbox user — the true
+     * owner-branch delete that plain CalDAV DELETE can never reach,
+     * because nobody authenticates as the mailbox principal (see
+     * handleCreateCalendar's docblock above). Django has already
+     * verified the caller holds sender/admin role on the mailbox
+     * before calling this; this handler re-derives the calendar from
+     * the CALLER's own (sharee) instance and only proceeds if that
+     * calendar is genuinely MAILBOX-owned and belongs to the mailbox
+     * Django checked against — fail-closed guards against a
+     * mismatched or forged request.
+     *
+     * ``$calendarUri`` is the URI the caller reads the calendar at
+     * under their own principal (``calendars/users/{caller}/{uri}/``),
+     * not the owner-side URI — the caller never sees the latter.
+     *
+     * Body: {"mailbox_email": "contact@company.com"}
+     */
+    private function handleDeleteMailboxCalendar($request, $response, $calendarUri)
+    {
+        $body = json_decode($request->getBodyAsString(), true) ?: [];
+        $mailboxEmail = $body['mailbox_email'] ?? null;
+        if (!$mailboxEmail) {
+            $response->setStatus(400);
+            $response->setHeader('Content-Type', 'application/json');
+            $response->setBody(json_encode(['error' => 'mailbox_email is required']));
+            return false;
+        }
+
+        $callerEmail = $request->getHeader('X-LS-User');
+        $orgId = $request->getHeader('X-LS-Org-Id');
+        if (!$callerEmail || !$orgId) {
+            $response->setStatus(400);
+            $response->setHeader('Content-Type', 'application/json');
+            $response->setBody(json_encode([
+                'error' => 'X-LS-User and X-LS-Org-Id headers are required',
+            ]));
+            return false;
+        }
+
+        $callerPrincipalUri = 'principals/users/' . $callerEmail;
+        $calendarInfo = $this->resolveCalendarInfo($callerPrincipalUri, $calendarUri);
+        if ($calendarInfo === null) {
+            $response->setStatus(404);
+            $response->setHeader('Content-Type', 'application/json');
+            $response->setBody(json_encode(['error' => 'Calendar not found']));
+            return false;
+        }
+        $calendarId = $calendarInfo['id'];
+
+        // Resolve the owner instance to verify this is really a
+        // MAILBOX-owned calendar belonging to the mailbox Django
+        // already checked the caller's role against.
+        try {
+            $stmt = $this->pdo->prepare(
+                'SELECT p.email, p.calendar_user_type, p.org_id'
+                . ' FROM calendarinstances ci'
+                . ' JOIN principals p ON p.uri = ci.principaluri'
+                . ' WHERE ci.calendarid = ? AND ci.access = 1'
+            );
+            $stmt->execute([$calendarId]);
+            $owner = $stmt->fetch(\PDO::FETCH_ASSOC);
+        } catch (\Exception $e) {
+            error_log('[InternalApiPlugin] Failed to look up calendar owner: ' . $e->getMessage());
+            $response->setStatus(500);
+            $response->setHeader('Content-Type', 'application/json');
+            $response->setBody(json_encode(['error' => 'Failed to look up calendar']));
+            return false;
+        }
+
+        if (!$owner || $owner['calendar_user_type'] !== PrincipalBackend::TYPE_MAILBOX) {
+            $response->setStatus(400);
+            $response->setHeader('Content-Type', 'application/json');
+            $response->setBody(json_encode(['error' => 'Not a mailbox-owned calendar']));
+            return false;
+        }
+
+        if (strcasecmp($owner['email'], $mailboxEmail) !== 0) {
+            $response->setStatus(403);
+            $response->setHeader('Content-Type', 'application/json');
+            $response->setBody(json_encode([
+                'error' => 'Calendar does not belong to the given mailbox',
+            ]));
+            return false;
+        }
+
+        // Fail-closed org check — same contract as handleDeleteResource
+        // and handleDeleteUser.
+        if (!$owner['org_id'] || $orgId !== $owner['org_id']) {
+            $response->setStatus(403);
+            $response->setHeader('Content-Type', 'application/json');
+            $response->setBody(json_encode([
+                'error' => 'Cannot delete a calendar from a different organization',
+            ]));
+            return false;
+        }
+
+        // Owner-branch delete: wipes calendarobjects, calendarchanges,
+        // and every calendarinstances row (owner + every sharee) for
+        // this calendarid — not just the caller's own row.
+        try {
+            $this->caldavBackend->deleteCalendar($calendarId);
+        } catch (\Exception $e) {
+            error_log('[InternalApiPlugin] Failed to delete mailbox calendar: ' . $e->getMessage());
+            $response->setStatus(500);
+            $response->setHeader('Content-Type', 'application/json');
+            $response->setBody(json_encode(['error' => 'Failed to delete calendar']));
+            return false;
+        }
+
+        $response->setStatus(200);
+        $response->setHeader('Content-Type', 'application/json');
+        $response->setBody(json_encode(['deleted' => true]));
         return false;
     }
 

--- a/src/frontend/src/features/calendar/components/calendar-list/hooks/useCalendarListState.ts
+++ b/src/frontend/src/features/calendar/components/calendar-list/hooks/useCalendarListState.ts
@@ -18,7 +18,10 @@ interface UseCalendarListStateProps {
     url: string,
     options: CalDavCalendarUpdate,
   ) => Promise<{ success: boolean; error?: string }>;
-  deleteCalendar: (url: string) => Promise<{ success: boolean; error?: string }>;
+  deleteCalendar: (
+    url: string,
+    mailboxEmail?: string,
+  ) => Promise<{ success: boolean; error?: string }>;
 }
 
 export const useCalendarListState = ({
@@ -148,7 +151,10 @@ export const useCalendarListState = ({
 
     setDeleteState((prev) => ({ ...prev, isLoading: true }));
     try {
-      const result = await deleteCalendar(deleteState.calendar.url);
+      const result = await deleteCalendar(
+        deleteState.calendar.url,
+        deleteState.calendar.mailboxEmail,
+      );
       if (!result.success) {
         console.error("Failed to delete calendar:", result.error);
       }

--- a/src/frontend/src/features/calendar/contexts/CalendarContext.tsx
+++ b/src/frontend/src/features/calendar/contexts/CalendarContext.tsx
@@ -14,6 +14,8 @@ import { EventCalendarAdapter } from "../services/dav/EventCalendarAdapter";
 import { caldavServerUrl } from "../utils/DavClient";
 import { addToast, ToasterItem } from "@/features/ui/components/toaster/Toaster";
 import { useAuth } from "@/features/auth/Auth";
+import { deleteMailboxCalendar } from "@/features/mailbox";
+import { errorToString } from "@/features/api/APIError";
 
 import type {
   CalDavCalendar,
@@ -69,7 +71,10 @@ export interface CalendarContextType {
     calendarUrl: string,
     params: { displayName?: string; color?: string; description?: string },
   ) => Promise<{ success: boolean; error?: string }>;
-  deleteCalendar: (calendarUrl: string) => Promise<{ success: boolean; error?: string }>;
+  deleteCalendar: (
+    calendarUrl: string,
+    mailboxEmail?: string,
+  ) => Promise<{ success: boolean; error?: string }>;
   shareCalendar: (
     calendarUrl: string,
     email: string,
@@ -250,28 +255,45 @@ export const CalendarContextProvider = ({ children }: CalendarContextProviderPro
   );
 
   const deleteCalendar = useCallback(
-    async (calendarUrl: string): Promise<{ success: boolean; error?: string }> => {
+    async (
+      calendarUrl: string,
+      mailboxEmail?: string,
+    ): Promise<{ success: boolean; error?: string }> => {
       try {
-        const result = await caldavService.deleteCalendar(calendarUrl);
-        if (result.success) {
-          // Remove from visible calendars
-          setVisibleCalendarUrls((prev) => {
-            const newSet = new Set(prev);
-            newSet.delete(calendarUrl);
-            return newSet;
-          });
-          await refreshCalendars();
-          return { success: true };
+        if (mailboxEmail) {
+          // A plain CalDAV DELETE on a mailbox-owned calendar only
+          // ever removes the caller's own share — the calendar
+          // reappears for everyone else. Go through the backend's
+          // owner-branch delete instead, which removes it for every
+          // mailbox user (see issue #72).
+          const calendarUri = calendarUrl.replace(/\/$/, "").split("/").pop() ?? "";
+          await deleteMailboxCalendar(mailboxEmail, calendarUri);
+        } else {
+          const result = await caldavService.deleteCalendar(calendarUrl);
+          if (!result.success) {
+            return {
+              success: false,
+              error: result.error || "Failed to delete calendar",
+            };
+          }
         }
-        return {
-          success: false,
-          error: result.error || "Failed to delete calendar",
-        };
+        // Remove from visible calendars
+        setVisibleCalendarUrls((prev) => {
+          const newSet = new Set(prev);
+          newSet.delete(calendarUrl);
+          return newSet;
+        });
+        await refreshCalendars();
+        return { success: true };
       } catch (error) {
         console.error("Error deleting calendar:", error);
         return {
           success: false,
-          error: error instanceof Error ? error.message : "Unknown error",
+          error: mailboxEmail
+            ? errorToString(error)
+            : error instanceof Error
+              ? error.message
+              : "Unknown error",
         };
       }
     },

--- a/src/frontend/src/features/mailbox/api.ts
+++ b/src/frontend/src/features/mailbox/api.ts
@@ -25,3 +25,23 @@ export async function setupCalendar(
   });
   return response.json();
 }
+
+/**
+ * Delete a MAILBOX-owned calendar for every mailbox user.
+ *
+ * Unlike a plain CalDAV DELETE (which only ever removes the caller's
+ * own share), this reaches the real owner-branch delete via the
+ * backend's internal API, so the calendar disappears for everyone.
+ *
+ * `calendarUri` is the URI the caller reads the calendar at under
+ * their own principal — the last path segment of the calendar's URL.
+ */
+export async function deleteMailboxCalendar(
+  mailboxEmail: string,
+  calendarUri: string,
+): Promise<void> {
+  await fetchAPI("setup/", {
+    method: "DELETE",
+    body: JSON.stringify({ mailbox_email: mailboxEmail, calendar_uri: calendarUri }),
+  });
+}

--- a/src/frontend/src/features/mailbox/index.ts
+++ b/src/frontend/src/features/mailbox/index.ts
@@ -1,3 +1,3 @@
 export { useMailboxSync } from "./useMailboxSync";
-export { fetchMailboxes, setupCalendar } from "./api";
+export { fetchMailboxes, setupCalendar, deleteMailboxCalendar } from "./api";
 export type { Mailbox, MailboxCalendarInfo, MailboxSyncResult } from "./types";


### PR DESCRIPTION
## Purpose

Closes #72. Calendars owned by a shared-mailbox principal (e.g. created
via `POST /api/v1.0/setup/` with `mailbox_email`) could be created without
limit but never truly deleted:

- The frontend "Delete calendar" action issues a plain CalDAV `DELETE`
  under the caller's own principal. For a MAILBOX-owned calendar the
  caller's `calendarinstances` row is a sharee row, never the owner —
  so this only ever removes the caller's own share; the underlying
  `calendars` row and its `calendarobjects` survive untouched.
- The true owner instance lives under `principals/mailboxes/{email}/…`,
  a principal nobody ever authenticates as, so no CalDAV client can
  ever reach the owner-branch delete.
- There was no internal-API route to hard-delete a plain calendar
  (only `POST .../calendars/` to create, and `DELETE .../resources/{id}`
  for a different object type).
- On top of that, the periodic mailbox ACL sync silently re-adds any
  share a user tries to remove on their own, as long as they still
  have a role on the mailbox — so even a partial workaround gets
  undone on the next reload.

## Proposal

- [x] New `DELETE /internal-api/calendars/{calendar_uri}` route in the
      CalDAV server (`InternalApiPlugin.php`). Resolves the calendar from
      the *caller's* own resolvable instance, verifies it is genuinely
      MAILBOX-owned and belongs to the mailbox the request claims, checks
      org scoping (fail-closed, same contract as the existing resource/user
      delete routes), then runs SabreDAV's stock owner-branch
      `deleteCalendar()` — no hand-rolled cascade SQL needed.
- [x] `SetupService.delete_mailbox_calendar()` (Django), gated by the same
      sender/admin mailbox-role check used for calendar *creation*
      (extracted into a shared `_require_mailbox_send_role` helper to avoid
      duplicating that check).
- [x] `DELETE /api/v1.0/setup/` (new method on the existing `SetupView`)
      taking `{mailbox_email, calendar_uri}`.
- [x] Frontend: `CalendarContext.deleteCalendar` now takes an optional
      `mailboxEmail` and, when set, calls the new backend endpoint instead
      of a plain CalDAV `DELETE` — removing the calendar for every mailbox
      user, not just the caller.
- [x] Backend tests covering auth, role gating, success, not-found, and
      cross-mailbox-ownership mismatch.

Note: unlimited *creation* of calendars under one mailbox is intentional
(documented use case: separate Personal / Triage / Out-of-office
calendars backed by the same mailbox) — this PR only adds the missing
deletion path, it does not change creation behavior.

## Test plan

- [x] `bin/pytest core/tests/test_setup_mailbox_calendar_delete.py` — 7/7 pass
- [x] `bin/pytest core/tests/` — full backend suite, 785/785 pass (no regressions)
- [x] `make typecheck-front` / `make lint-front` — clean
- [x] `make test-front` — 221/221 pass (no regressions)
- [x] `php -l` on the modified PHP file — no syntax errors